### PR TITLE
Issue #9: Fix commons-lang dependency to use version 2.5

### DIFF
--- a/hraven-core/pom.xml
+++ b/hraven-core/pom.xml
@@ -177,9 +177,9 @@
       <version>1.2</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.1</version>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.5</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
This modifies the commons-lang dependency for hraven-core to match the version of the classes we actually use.  The previously declared commons-lang3 classes use distinct package names (org.apache.commons.lang3.*) which don't match what we actually use.
