### PR TITLE
Issue #50 Add a new job history key called "diagnostics" in hadoop2

### DIFF
--- a/hraven-core/src/main/java/com/twitter/hraven/JobHistoryKeys.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobHistoryKeys.java
@@ -68,6 +68,7 @@ public enum JobHistoryKeys {
 	JOB_QUEUE(String.class, "jobQueueName"),
 	// hadoop 2.0 related keys {@link JobHistoryParser}
   hadoopversion(String.class, null),
+  diagnostics(String.class, null),
   applicationAttemptId(String.class, null),
   containerId(String.class, null),
   successfulAttemptId(String.class, null),

--- a/hraven-core/src/test/java/com/twitter/hraven/TestJobHistoryKeys.java
+++ b/hraven-core/src/test/java/com/twitter/hraven/TestJobHistoryKeys.java
@@ -25,7 +25,7 @@ public class TestJobHistoryKeys {
       applicationAttemptId, containerId, nodeManagerHost,
       successfulAttemptId, failedDueToAttempt,
       workflowId, workflowName, workflowNodeName,
-      workflowAdjacencies, locality, avataar,
+      workflowAdjacencies, locality, avataar, diagnostics,
       hadoopversion, nodeManagerPort, nodeManagerHttpPort,
       acls, uberized, shufflePort, mapFinishTime,
       port, rackname, clockSplits, cpuUsages,


### PR DESCRIPTION
The new field will be added as per patch in MAPREDUCE-5648 and YARN-1551.
These jiras are to add a reason (message / diagnostics) as to why a job got killed.
(current patch there does not preserve the reason in the history file, but that patch-update will be forthcoming shortly).
Adding an additional key is backwards compatible, meaning that history file that do not have it can still be processed w/o breakage.
