### PR TITLE
Output REST api metrics stats 

### DIFF
--- a/hraven-core/pom.xml
+++ b/hraven-core/pom.xml
@@ -168,6 +168,36 @@
       <version>0.0.98</version>
     </dependency>
     <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>application</artifactId>
+      <version>0.0.45</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>application-module-http</artifactId>
+      <version>0.0.45</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>application-module-stats</artifactId>
+      <version>0.0.44</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>application-module-applauncher</artifactId>
+      <version>0.0.45</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>application-module-log</artifactId>
+      <version>0.0.45</version>
+    </dependency>
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>net-http</artifactId>
+      <version>0.0.45</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
@@ -186,6 +216,16 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.6.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.7</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -268,14 +308,6 @@
         <exclusion>
           <groupId>org.mortbay.jetty</groupId>
           <artifactId>servlet-api-2.5</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/hraven-core/src/main/java/com/twitter/hraven/HravenResponseMetrics.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/HravenResponseMetrics.java
@@ -5,43 +5,57 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.twitter.common.stats.Stats;
 
+/**
+ * defines the metrics to be collected
+ *
+ */
 public class HravenResponseMetrics {
   public final static String JOB_API_LATENCY = "JOB_API_LATENCY";
   public static AtomicLong JOB_API_LATENCY_VALUE;
+
   public final static String FLOW_API_LATENCY = "FLOW_API_LATENCY";
   public static AtomicLong FLOW_API_LATENCY_VALUE;
+
+  public final static String FLOW_STATS_API_LATENCY = "FLOW_STATS_API_LATENCY";
+  public static AtomicLong FLOW_STATS_API_LATENCY_VALUE;
+
+  public final static String FLOW_VERSION_API_LATENCY = "FLOW_VERSION_API_LATENCY";
+  public static AtomicLong FLOW_VERSION_API_LATENCY_VALUE;
+
   public final static String FLOW_HBASE_RESULT_SIZE = "FLOW_HBASE_RESULT_SIZE";
   public static AtomicDouble FLOW_HBASE_RESULT_SIZE_VALUE;
-  
-  static {
-    JOB_API_LATENCY_VALUE = Stats.exportLong(JOB_API_LATENCY);
-    FLOW_HBASE_RESULT_SIZE_VALUE = Stats.exportDouble(FLOW_HBASE_RESULT_SIZE);
-    FLOW_API_LATENCY_VALUE = Stats.exportLong(FLOW_API_LATENCY);
-  }
 
-  /*JOBFLOW_API_LATENCY,
-  FLOW_API_LATENCY,
-  FLOW_VERSION_API_LATENCY,
-  FLOWSTATS_API_LATENCY,
-  TASKS_API_LATENCY,
-  APPVERSIONS_API_LATENCY,
-  HDFS_STATS_API_LATENCY,
-  HDFS_TIMESERIES_API_LATENCY,
-  NEWJOBS_API_LATENCY,
-  FLOW_VERSION_API_NUM_FLOWS,
-  FLOWSTATS_API_NUM_FLOWS, //(Stats.exportLong(HravenResponseMetrics.FLOWSTATS_API_NUM_FLOWS.toString())),
-  FLOW_API_NUM_FLOWS,
-  TASKS_API_NUM_TASKS,
-  APPVERSIONS_API_NUM_VERSIONS,
-  HDFS_STATS_API_NUM_STATS,
-  HDFS_TIMESERIES_API_NUM_STATS,
-  NEWJOBS_API_NUM_APPS,
-  JOBS_HBASE_RESULT_SIZE,
-  JOBFLOW_API_RESPONSE_SIZE,
-  FLOW_HBASE_RESULT_SIZE,
-  APPVERSIONS_RESPONSE_SIZE,
-  HDFS_API_RESPONSE_SIZE,
-  HDFS_TIMESERIES_API_RESPONSE_SIZE,
-  NEWJOBS_API_RESPONSE_SIZE;
-*/
+  public final static String JOBFLOW_API_LATENCY = "JOBFLOW_API_LATENCY";
+  public static AtomicLong JOBFLOW_API_LATENCY_VALUE;
+
+  public final static String TASKS_API_LATENCY = "TASKS_API_LATENCY";
+  public static AtomicLong TASKS_API_LATENCY_VALUE;
+
+  public final static String APPVERSIONS_API_LATENCY = "APPVERSIONS_API_LATENCY";
+  public static AtomicLong APPVERSIONS_API_LATENCY_VALUE;
+
+  public final static String HDFS_STATS_API_LATENCY = "HDFS_STATS_API_LATENCY";
+  public static AtomicLong HDFS_STATS_API_LATENCY_VALUE;
+
+  public final static String HDFS_TIMESERIES_API_LATENCY = "HDFS_TIMESERIES_API_LATENCY";
+  public static AtomicLong HDFS_TIMESERIES_API_LATENCY_VALUE;
+
+  public final static String NEW_JOBS_API_LATENCY = "NEW_JOBS_API_LATENCY";
+  public static AtomicLong NEW_JOBS_API_LATENCY_VALUE;
+
+  static {
+    /** initialize metrics */
+    JOB_API_LATENCY_VALUE = Stats.exportLong(JOB_API_LATENCY);
+    FLOW_API_LATENCY_VALUE = Stats.exportLong(FLOW_API_LATENCY);
+    FLOW_STATS_API_LATENCY_VALUE = Stats.exportLong(FLOW_STATS_API_LATENCY);
+    FLOW_VERSION_API_LATENCY_VALUE = Stats.exportLong(FLOW_VERSION_API_LATENCY);
+    FLOW_HBASE_RESULT_SIZE_VALUE = Stats.exportDouble(FLOW_HBASE_RESULT_SIZE);
+    JOBFLOW_API_LATENCY_VALUE = Stats.exportLong(JOBFLOW_API_LATENCY);
+    TASKS_API_LATENCY_VALUE = Stats.exportLong(TASKS_API_LATENCY);
+    APPVERSIONS_API_LATENCY_VALUE = Stats.exportLong(APPVERSIONS_API_LATENCY);
+    HDFS_STATS_API_LATENCY_VALUE = Stats.exportLong(HDFS_STATS_API_LATENCY);
+    HDFS_TIMESERIES_API_LATENCY_VALUE = Stats.exportLong(HDFS_TIMESERIES_API_LATENCY);
+    NEW_JOBS_API_LATENCY_VALUE = Stats.exportLong(NEW_JOBS_API_LATENCY);
+
+  }
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/JobDetails.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobDetails.java
@@ -557,7 +557,6 @@ public class JobDetails implements Comparable<JobDetails> {
     this.failedReduces = getValueAsLong(JobHistoryKeys.FAILED_REDUCES, infoValues);
 
     this.config = JobHistoryService.parseConfiguration(infoValues);
-    LOG.debug("====== config size="+ this.config.size());
     this.queue = this.config.get(Constants.HRAVEN_QUEUE);
     this.counters = JobHistoryService.parseCounters(Constants.COUNTER_COLUMN_PREFIX_BYTES,
         infoValues);

--- a/hraven-core/src/main/java/com/twitter/hraven/rest/HravenRestServer.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/rest/HravenRestServer.java
@@ -1,0 +1,87 @@
+/*
+Copyright 2013 Twitter, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.twitter.hraven.rest;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Module;
+import com.twitter.common.application.AbstractApplication;
+import com.twitter.common.application.modules.HttpModule;
+import com.twitter.common.application.modules.StatsModule;
+import com.twitter.common.application.AppLauncher;
+import com.twitter.common.application.Lifecycle;
+import com.twitter.common.application.modules.LogModule;
+
+import com.twitter.common.net.http.HttpServerDispatch;
+import com.twitter.common.stats.Stats;
+
+/**
+ * This is the application that launches the REST API
+ * It also exposes the metrics collected via the Stats System
+ * at http://hostname:portnum/vars or
+ * http://hostname:portnum/vars.json
+ * These metrics can be collected from a plugin to be fed into
+ * to any metric collection system
+ */
+public class HravenRestServer extends AbstractApplication {
+  private static final Log LOG = LogFactory.getLog(HravenRestServer.class);
+
+  @Inject private Lifecycle lifecycle;
+  @Inject private HttpServerDispatch httpServer;
+
+  @Override
+  public void run() {
+    LOG.info("Running");
+    Map<String, String> initParams = Maps.newHashMap();
+    initParams.put("com.sun.jersey.config.property.packages", "com.twitter.hraven.rest");
+    initParams.put("com.sun.jersey.api.json.POJOMappingFeature", "true");
+
+    httpServer.registerHandler("/",
+      new com.sun.jersey.spi.container.servlet.ServletContainer(), initParams, false);
+
+    // export a metric that printouts the epoch time this service came up
+    // metrics can be viewed at hostname:portnumber/vars or
+    // hostname:portnumber/vars.json
+    Stats.exportLong("hravenRestService_StartTimestamp", System.currentTimeMillis());
+
+    // await shutdown
+    lifecycle.awaitShutdown();
+  }
+
+  /**
+   * This tells AppLauncher what modules to load
+   */
+  @Override
+  public Iterable<? extends Module> getModules() {
+    return Arrays.asList(
+      new HttpModule(),
+      new LogModule(),
+      new StatsModule()
+    );
+  }
+
+  public static void main(String[] args) {
+    AppLauncher.launch(HravenRestServer.class, args);
+  }
+}
+

--- a/hraven-core/src/main/java/com/twitter/hraven/rest/RestServer.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/rest/RestServer.java
@@ -35,6 +35,7 @@ import com.sun.jersey.spi.container.servlet.ServletContainer;
 
 /**
  * Simple REST server that spawns an embedded Jetty instance to service requests
+ * @deprecated in favor of {@link HravenRestServer}
  */
 public class RestServer extends AbstractIdleService {
   /** Default TCP port for the server to listen on */
@@ -96,7 +97,7 @@ public class RestServer extends AbstractIdleService {
         "To run the REST server, execute bin/hraven rest start|stop [-p <port>]", true);
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
     // parse commandline options
     Options opts = new Options();
     opts.addOption("p", "port", true, "Port for server to bind to (default 8080)");
@@ -125,7 +126,7 @@ public class RestServer extends AbstractIdleService {
       address = cmd.getOptionValue("a");
     }
     RestServer server = new RestServer(address, port);
-    server.startAndWait();
+    server.startUp();
     // run until we're done
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <junit.version>4.8.1</junit.version>
     <mockito-all.version>1.8.5</mockito-all.version>
     <log4j.version>1.2.15</log4j.version>
-    <guava.version>12.0</guava.version>
+    <guava.version>14.0</guava.version>
     <jersey.version>1.12</jersey.version>
     <jackson.version>1.9.6</jackson.version>
 


### PR DESCRIPTION
This PR adds a new RestServer that launches the REST API. It also exposes the metrics collected via the Stats System  at http://hostname:portnum/vars or http://hostname:portnum/vars.json . These metrics can be collected from a plugin to be fed into to any metric collection system
