### PR TITLE
Refactoring hraven for multiple sink support

### DIFF
--- a/bin/etl/hraven-etl.sh
+++ b/bin/etl/hraven-etl.sh
@@ -42,6 +42,8 @@ hbaseconfdir=${HBASE_CONF_DIR:-$HBASE_HOME/conf}
 # HDFS directories for processing and loading job history data
 historyRawDir=/yarn/history/done/
 historyProcessingDir=/hraven/processing/
+sinks=GRAPHITE,HBASE
+jobFileProcessorConfOpts=-Dhraven.sink.graphite.userfilter=rmcuser -Dhraven.sink.graphite.queuefilter=userplatform -Dhraven.sink.graphite.excludedcomponents=MultiInputCounters
 #######################################################
 
 #If costfile is empty, fill it with default values
@@ -71,4 +73,4 @@ $home/jobFilePreprocessor.sh $hadoopconfdir $historyRawDir $historyProcessingDir
 $home/jobFileLoader.sh $hadoopconfdir $mapredmaxsplitsize $schedulerpoolname $cluster $historyProcessingDir
 
 # Process
-$home/jobFileProcessor.sh $hbaseconfdir $schedulerpoolname $historyProcessingDir $cluster $threads $batchsize $machinetype $costfile
+$home/jobFileProcessor.sh $hbaseconfdir $schedulerpoolname $historyProcessingDir $cluster $threads $batchsize $machinetype $costfile $sinks $jobFileProcessorConfOpts

--- a/bin/etl/jobFileProcessor.sh
+++ b/bin/etl/jobFileProcessor.sh
@@ -21,9 +21,9 @@
 #   [schedulerpoolname] [historyprocessingdir] [cluster] [threads] [batchsize] [machinetype] [costfile]
 # a sample cost file can be found in the conf dir as sampleCostDetails.properties
 
-if [ $# -ne 8 ]
+if [ $# -ne 10 ]
 then
-  echo "Usage: `basename $0` [hbaseconfdir] [schedulerpoolname] [historyprocessingdir] [cluster] [threads] [batchsize] [machinetype] [costfile]"
+  echo "Usage: `basename $0` [hbaseconfdir] [schedulerpoolname] [historyprocessingdir] [cluster] [threads] [batchsize] [machinetype] [costfile] [sinks] [jobfileprocessorconf]"
   exit 1
 fi
 
@@ -40,5 +40,5 @@ fi
 create_pidfile $HRAVEN_PID_DIR
 trap 'cleanup_pidfile_and_exit $HRAVEN_PID_DIR' INT TERM EXIT
 
-hadoop --config $1 jar $hravenEtlJar com.twitter.hraven.etl.JobFileProcessor -libjars=$LIBJARS -Dmapred.fairscheduler.pool=$2 -d -p $3 -c $4 -t $5 -b $6 -m $7 -z $8
+hadoop --config $1 jar $hravenEtlJar com.twitter.hraven.etl.JobFileProcessor -libjars=$LIBJARS -Dmapred.fairscheduler.pool=$2 ${10} -d -p $3 -c $4 -t $5 -b $6 -m $7 -z $8 -s $9
 

--- a/hraven-core/src/main/java/com/twitter/hraven/AppKey.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/AppKey.java
@@ -16,27 +16,33 @@ limitations under the License.
 
 package com.twitter.hraven;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparable;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 
-public class AppKey implements Comparable<Object> {
+public class AppKey implements WritableComparable<Object> {
 
   /**
    * The cluster on which the application ran
    */
-  protected final String cluster;
+  protected String cluster;
   /**
    * Who ran the application on Hadoop
    */
-  protected final String userName;
+  protected String userName;
 
   /**
    * The thing that identifies an application,
    * such as Pig script identifier, or Scalding identifier.
    */
-  protected final String appId;
+  protected String appId;
 
   @JsonCreator
   public AppKey(@JsonProperty("cluster") String cluster, @JsonProperty("userName") String userName,
@@ -109,6 +115,20 @@ public class AppKey implements Comparable<Object> {
         .append(this.userName)
         .append(this.appId)
         .toHashCode();
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    Text.writeString(out, this.cluster);
+    Text.writeString(out, this.userName);
+    Text.writeString(out, this.appId);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    this.cluster = Text.readString(in);
+    this.userName = Text.readString(in);
+    this.appId = Text.readString(in);
   }
 
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/Constants.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/Constants.java
@@ -31,6 +31,8 @@ public class Constants {
   public static final char SEP_CHAR = '!';
   public static final String SEP = "" + SEP_CHAR;
   public static final byte[] SEP_BYTES = Bytes.toBytes(SEP);
+  
+  public static final String PERIOD_SEP_CHAR = ".";
 
   // common default values
   public static final byte[] EMPTY_BYTES = new byte[0];
@@ -426,4 +428,29 @@ public class Constants {
 
   /** name of the properties file used for cluster to cluster identifier mapping */
   public static final String HRAVEN_CLUSTER_PROPERTIES_FILENAME = "hRavenClusters.properties";
+
+  public static final String JOBCONF_SINKS = "hraven.sinks";
+  
+  public static final String JOBCONF_GRAPHITE_HOST_KEY = "hraven.sink.graphite.host";
+  public static final String JOBCONF_GRAPHITE_PORT_KEY = "hraven.sink.graphite.port";
+  public static final String JOBCONF_GRAPHITE_PREFIX = "hraven.sink.graphite.prefix";
+  public static final String JOBCONF_GRAPHITE_USER_FILTER = "hraven.sink.graphite.userfilter";
+  public static final String JOBCONF_GRAPHITE_QUEUE_FILTER = "hraven.sink.graphite.queuefilter";
+  public static final String JOBCONF_GRAPHITE_EXCLUDED_COMPONENTS = "hraven.sink.graphite.excludedcomponents";
+  public static final String JOBCONF_GRAPHITE_DONOTEXCLUDE_APPS = "hraven.sink.graphite.donotexcludeapps";
+  
+  public static final int GRAPHITE_DEFAULT_PORT = 2003;
+  public static final String GRAPHITE_DEFAULT_HOST = "localhost";
+  public static final String GRAPHITE_DEFAULT_PREFIX = "DEFAULT";
+  
+  public static final String GRAPHITE_KEY_MAPPING_TABLE = PREFIX + "graphite_key_mapping";
+  public static final byte[] GRAPHITE_KEY_MAPPING_TABLE_BYTES = Bytes.toBytes(GRAPHITE_KEY_MAPPING_TABLE);
+  
+  public static final String GRAPHITE_REVERSE_KEY_MAPPING_TABLE = PREFIX + "graphite_key_mapping_r";
+  public static final byte[] GRAPHITE_REVERSE_KEY_MAPPING_TABLE_BYTES = Bytes.toBytes(GRAPHITE_REVERSE_KEY_MAPPING_TABLE);
+  
+  public static final String GRAPHITE_KEY_MAPPING_COLUMN = "k";
+  public static final byte[] GRAPHITE_KEY_MAPPING_COLUMN_BYTES = Bytes.toBytes(GRAPHITE_KEY_MAPPING_COLUMN);
+
+  
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/FlowKey.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/FlowKey.java
@@ -15,12 +15,19 @@ limitations under the License.
 */
 package com.twitter.hraven;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparable;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 
-public class FlowKey extends AppKey implements Comparable<Object> {
+public class FlowKey extends AppKey implements WritableComparable<Object> {
 
   /**
    * Identifying one single run of a version of an app. Smaller values indicate
@@ -111,4 +118,17 @@ public class FlowKey extends AppKey implements Comparable<Object> {
           .toHashCode();
   }
 
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    new LongWritable(this.runId).write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    LongWritable lw = new LongWritable();
+    lw.readFields(in);
+    this.runId = lw.get();
+  }
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/HravenRecord.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/HravenRecord.java
@@ -1,0 +1,172 @@
+package com.twitter.hraven;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Writable;
+
+import com.twitter.hraven.util.EnumWritable;
+import com.twitter.hraven.util.Serializer;
+
+/**
+ * 
+ * @author angad.singh
+ *
+ * {@link JobFileTableMapper outputs this as value. It corresponds to the
+ * Put record which was earlier emitted
+ * 
+ * @param <K> key type
+ * @param <V> type of dataValue object to be stored
+ */
+
+public abstract class HravenRecord<K extends Writable, V> implements Writable{
+  private K key;
+  private RecordCategory dataCategory;
+  private RecordDataKey dataKey;
+  private V dataValue;
+  private Long submitTime;
+
+  public HravenRecord() {
+
+  }
+
+  public K getKey() {
+    return key;
+  }
+
+  public void setKey(K key) {
+    this.key = key;
+  }
+
+  public RecordCategory getDataCategory() {
+    return dataCategory;
+  }
+
+  public void setDataCategory(RecordCategory dataCategory) {
+    this.dataCategory = dataCategory;
+  }
+
+  public RecordDataKey getDataKey() {
+    return dataKey;
+  }
+
+  public void setDataKey(RecordDataKey dataKey) {
+    this.dataKey = dataKey;
+  }
+
+  public V getDataValue() {
+    return dataValue;
+  }
+
+  public void setDataValue(V dataValue) {
+    this.dataValue = dataValue;
+  }
+
+  public Long getSubmitTime() {
+    return submitTime;
+  }
+
+  public void setSubmitTime(Long submitTime) {
+    this.submitTime = submitTime;
+  }
+  
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((dataCategory == null) ? 0 : dataCategory.hashCode());
+    result = prime * result + ((dataKey == null) ? 0 : dataKey.hashCode());
+    result = prime * result + ((dataValue == null) ? 0 : dataValue.hashCode());
+    result = prime * result + ((key == null) ? 0 : key.hashCode());
+    result = prime * result + (int) (submitTime ^ (submitTime >>> 32));
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    HravenRecord other = (HravenRecord) obj;
+    if (dataCategory != other.dataCategory) {
+      return false;
+    }
+    if (dataKey == null) {
+      if (other.dataKey != null) {
+        return false;
+      }
+    } else if (!dataKey.equals(other.dataKey)) {
+      return false;
+    }
+    if (dataValue == null) {
+      if (other.dataValue != null) {
+        return false;
+      }
+    } else if (!dataValue.equals(other.dataValue)) {
+      return false;
+    }
+    if (key == null) {
+      if (other.key != null) {
+        return false;
+      }
+    } else if (!key.equals(other.key)) {
+      return false;
+    }
+    if (submitTime != other.submitTime) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "HravenRecord [key=" + key + ", dataCategory=" + dataCategory + ", dataKey=" + dataKey
+        + ", dataValue=" + dataValue + ", submitTime=" + submitTime + "]";
+  }
+  
+  @Override
+  public void write(DataOutput out) throws IOException {
+    //key
+    this.key.write(out);
+    //dataCategory
+    new EnumWritable(this.dataCategory).write(out);
+    //dataKey
+    this.dataKey.write(out);
+    //dataValue
+    byte[] b = Serializer.serialize(this.dataValue);
+    out.writeInt(b.length);
+    out.write(b);
+    //submitTime
+    new LongWritable(this.submitTime).write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    //key
+    this.key.readFields(in);
+    //dataCategory
+    new EnumWritable(this.dataCategory).readFields(in);
+    //dataKey
+    this.dataKey.readFields(in);
+    //dataValue
+    byte[] b = new byte[in.readInt()];
+    in.readFully(b);
+    try {
+      this.dataValue = (V) Serializer.deserialize(b);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Failure in deserializing HravenRecord.dataValue");
+    }
+    //submitTime
+    LongWritable lw = new LongWritable();
+    lw.readFields(in);
+    this.submitTime = lw.get();
+  }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/HravenService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/HravenService.java
@@ -1,0 +1,32 @@
+package com.twitter.hraven;
+
+/**
+ * 
+ * @author angad.singh
+ *
+ * {@link JobFileTableMapper} outputs this as key. It corresponds to the
+ * Hbase table which was earlier emitted
+ */
+
+public enum HravenService {
+  JOB_HISTORY_RAW {
+    @Override
+    public HravenRecord getNewRecord() {
+      return new JobHistoryRawRecord();
+    }
+  },
+  JOB_HISTORY {
+    @Override
+    public HravenRecord getNewRecord() {
+      return new JobHistoryRecord();
+    }
+  },
+  JOB_HISTORY_TASK {
+    @Override
+    public HravenRecord getNewRecord() {
+      return new JobHistoryTaskRecord();
+    }
+  };
+
+  public abstract HravenRecord getNewRecord();
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/JobHistoryRawRecord.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobHistoryRawRecord.java
@@ -1,0 +1,40 @@
+package com.twitter.hraven;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.hadoop.io.Text;
+
+public class JobHistoryRawRecord extends HravenRecord<Text, Object> {
+
+  public JobHistoryRawRecord(RecordCategory dataCategory, String key, RecordDataKey dataKey,
+      Object dataValue) {
+    this.setKey(new Text(key));
+    this.setDataCategory(dataCategory);
+    this.setDataKey(dataKey);
+    this.setDataValue(dataValue);
+  }
+
+  public JobHistoryRawRecord() {
+
+  }
+
+  public JobHistoryRawRecord(String rawKey) {
+    this.setKey(new Text(rawKey));
+  }
+
+  public void set(RecordCategory category, RecordDataKey key, String value) {
+    this.setDataCategory(category);
+    this.setDataKey(key);
+    this.setDataValue(value);
+  }
+
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+  }
+
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+  }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/JobHistoryRecord.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobHistoryRecord.java
@@ -1,0 +1,51 @@
+package com.twitter.hraven;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author angad.singh Abstraction of a record to be stored in the {@link HravenService#JOB_HISTORY}
+ *         service. Was earlier directly written as an Hbase put
+ */
+
+public class JobHistoryRecord extends HravenRecord<JobKey, Object> {
+
+  public JobHistoryRecord(RecordCategory dataCategory, JobKey key, RecordDataKey dataKey,
+      Object dataValue) {
+    this.setKey(key);
+    this.setDataCategory(dataCategory);
+    this.setDataKey(dataKey);
+    this.setDataValue(dataValue);
+  }
+
+  public JobHistoryRecord(RecordCategory dataCategory, JobKey key, RecordDataKey dataKey,
+      Object dataValue, Long submitTime) {
+    this(dataCategory, key, dataKey, dataValue);
+    setSubmitTime(submitTime);
+  }
+
+  public JobHistoryRecord() {
+
+  }
+
+  public JobHistoryRecord(JobKey jobKey) {
+    this.setKey(jobKey);
+  }
+
+  public void set(RecordCategory category, RecordDataKey key, String value) {
+    this.setDataCategory(category);
+    this.setDataKey(key);
+    this.setDataValue(value);
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+  }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/JobHistoryRecordCollection.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobHistoryRecordCollection.java
@@ -1,0 +1,245 @@
+package com.twitter.hraven;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * @author angad.singh Store multiple {@link JobHistoryRecord}s in a 2 level HashMap Supports
+ *         iteration to get individual {@link JobHistoryRecord}s
+ */
+
+public class JobHistoryRecordCollection extends HravenRecord<JobKey, Object> implements
+    Collection<JobHistoryRecord> {
+
+  private Map<RecordCategory, Map<RecordDataKey, Object>> valueMap;
+
+  public JobHistoryRecordCollection() {
+    valueMap = new HashMap<RecordCategory, Map<RecordDataKey, Object>>();
+  }
+
+  public JobHistoryRecordCollection(JobKey jobKey) {
+    setKey(jobKey);
+    valueMap = new HashMap<RecordCategory, Map<RecordDataKey, Object>>();
+  }
+
+  public JobHistoryRecordCollection(JobHistoryRecord record) {
+    valueMap = new HashMap<RecordCategory, Map<RecordDataKey, Object>>();
+    setKey(record.getKey());
+    setSubmitTime(record.getSubmitTime());
+    add(record);
+  }
+
+  public boolean add(RecordCategory category, RecordDataKey key, Object value) {
+    if (valueMap.containsKey(category)) {
+      valueMap.get(category).put(key, value);
+    } else {
+      HashMap<RecordDataKey, Object> categoryMap = new HashMap<RecordDataKey, Object>();
+      valueMap.put(category, categoryMap);
+      categoryMap.put(key, value);
+    }
+    
+    return true;
+  }
+
+  public boolean add(JobHistoryRecord record) {
+    return add(record.getDataCategory(), record.getDataKey(), record.getDataValue());
+  }
+
+  public Map<RecordCategory, Map<RecordDataKey, Object>> getValueMap() {
+    return valueMap;
+  }
+
+  public Object getValue(RecordCategory category, RecordDataKey key) {
+    return valueMap.containsKey(category) ? valueMap.get(category).get(key) : null;
+  }
+
+  public int size() {
+    int size = 0;
+    for (Entry<RecordCategory, Map<RecordDataKey, Object>> catMap : valueMap.entrySet()) {
+      size += catMap.getValue().size();
+    }
+
+    return size;
+  }
+
+  /**
+   * Be able to iterate easily to get individual {@link JobHistoryRecord}s
+   */
+
+  @Override
+  public Iterator<JobHistoryRecord> iterator() {
+
+    return new Iterator<JobHistoryRecord>() {
+
+      private Iterator<Entry<RecordCategory, Map<RecordDataKey, Object>>> catIterator;
+      private Iterator<Entry<RecordDataKey, Object>> dataIterator;
+      Entry<RecordCategory, Map<RecordDataKey, Object>> nextCat;
+      Entry<RecordDataKey, Object> nextData;
+
+      {
+        initIterators();
+      }
+
+      private void initIterators() {
+        if (catIterator == null) {
+          catIterator = valueMap.entrySet().iterator();
+        }
+
+        if (catIterator.hasNext()) {
+          nextCat = catIterator.next();
+          dataIterator = nextCat.getValue().entrySet().iterator();
+        }
+      }
+
+      @Override
+      public boolean hasNext() {
+        if (dataIterator == null) {
+          initIterators();
+        }
+        return dataIterator == null ? false : dataIterator.hasNext() || catIterator.hasNext();
+      }
+
+      @Override
+      public JobHistoryRecord next() {
+        if (!dataIterator.hasNext()) {
+          nextCat = catIterator.next();
+          dataIterator = nextCat.getValue().entrySet().iterator();
+        }
+
+        nextData = dataIterator.next();
+
+        return new JobHistoryRecord(nextCat.getKey(), getKey(), nextData.getKey(),
+            nextData.getValue(), getSubmitTime());
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+
+    };
+  }
+
+  public void mergeWith(JobHistoryRecordCollection confRecord) {
+    for (JobHistoryRecord record : confRecord) {
+      add(record);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((valueMap == null) ? 0 : valueMap.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    JobHistoryRecordCollection other = (JobHistoryRecordCollection) obj;
+    if (valueMap == null) {
+      if (other.valueMap != null) {
+        return false;
+      }
+    } else if (!valueMap.equals(other.valueMap)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return "JobHistoryRecordCollection [key=" + getKey() + ", dataCategory=" + getDataCategory() + ", dataKey=" + getDataKey()
+        + ", dataValue=" + getDataValue() + ", submitTime=" + getSubmitTime() + ", valueMap=" + valueMap + "]";
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return valueMap.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object[] toArray() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends JobHistoryRecord> recordCol) {
+    for (JobHistoryRecord record : recordCol) {
+      add(record);
+    }
+    return true;
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void clear() {
+    this.valueMap = null;
+  }
+
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    
+    out.writeInt(this.size());
+    for (JobHistoryRecord r: this) {
+      r.write(out);
+    }
+  }
+
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    
+    int size = in.readInt();
+    int i = 0;
+    while (i < size) {
+      JobHistoryRecord r = new JobHistoryRecord();
+      r.readFields(in);
+      this.add(r);
+      i++;
+    }
+  }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/JobHistoryTaskRecord.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobHistoryTaskRecord.java
@@ -1,0 +1,49 @@
+package com.twitter.hraven;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * @author angad.singh Abstraction of a record to be stored in the
+ *         {@link HravenService#JOB_HISTORY_TASK} service.
+ */
+
+public class JobHistoryTaskRecord extends HravenRecord<TaskKey, Object> {
+
+  public JobHistoryTaskRecord(RecordCategory dataCategory, TaskKey key, RecordDataKey dataKey,
+      Object dataValue) {
+    this.setKey(key);
+    this.setDataCategory(dataCategory);
+    this.setDataKey(dataKey);
+    this.setDataValue(dataValue);
+  }
+
+  public JobHistoryTaskRecord(RecordCategory dataCategory, TaskKey key, RecordDataKey dataKey,
+      Object dataValue, Long submitTime) {
+    this(dataCategory, key, dataKey, dataValue);
+    setSubmitTime(submitTime);
+  }
+
+  public JobHistoryTaskRecord() {
+
+  }
+
+  public JobHistoryTaskRecord(TaskKey jobKey) {
+    this.setKey(jobKey);
+  }
+
+  public void set(RecordCategory category, RecordDataKey key, String value) {
+    this.setDataCategory(category);
+    this.setDataKey(key);
+    this.setDataValue(value);
+  }
+
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+  }
+
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+  }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/JobId.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobId.java
@@ -15,8 +15,14 @@ limitations under the License.
 */
 package com.twitter.hraven;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.WritableComparable;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -25,7 +31,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * apart.  The jobtracker ID is parsed as: job_[epoch]_[sequence]
  *
  */
-public class JobId implements Comparable<JobId> {
+public class JobId implements WritableComparable<JobId> {
   protected static final String JOB_ID_SEP = "_";
   /**
    * The jobtracker start time from the job ID, obtained from parsing the
@@ -135,5 +141,20 @@ public class JobId implements Comparable<JobId> {
           .append(this.jobEpoch)
           .append(this.jobSequence)
           .toHashCode();
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    new LongWritable(this.jobEpoch).write(out);
+    new LongWritable(this.jobSequence).write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    LongWritable lw = new LongWritable();
+    lw.readFields(in);
+    this.jobEpoch = lw.get();
+    lw.readFields(in);
+    this.jobSequence = lw.get();
   }
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/JobKey.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/JobKey.java
@@ -15,8 +15,13 @@ limitations under the License.
 */
 package com.twitter.hraven;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.hadoop.io.WritableComparable;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -24,7 +29,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * Represents the row key for a given job. Row keys are stored as: username !
  * appid ! version ! runid ! jobid
  */
-public class JobKey extends FlowKey implements Comparable<Object>{
+public class JobKey extends FlowKey implements WritableComparable<Object>{
 
   /**
    * Fully qualified cluster + parsed job identifier
@@ -140,6 +145,18 @@ public class JobKey extends FlowKey implements Comparable<Object>{
       return new HashCodeBuilder().appendSuper(super.hashCode())
           .append(this.jobId)
           .toHashCode();
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    this.jobId.write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    this.jobId.readFields(in);
   }
 
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/QualifiedJobId.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/QualifiedJobId.java
@@ -15,6 +15,12 @@ limitations under the License.
 */
 package com.twitter.hraven;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 
@@ -25,12 +31,12 @@ import org.codehaus.jackson.annotate.JsonProperty;
  * current one). This class represents the fully qualified job identifier.
  * 
  */
-public class QualifiedJobId extends JobId {
+public class QualifiedJobId extends JobId implements Writable {
 
   /**
    * The Hadoop cluster on which the job ran.
    */
-  private final String cluster;
+  private String cluster;
 
   /**
    * Constructor.
@@ -55,6 +61,18 @@ public class QualifiedJobId extends JobId {
    */
   public String getCluster() {
     return cluster;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    Text.writeString(out, this.cluster);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    this.cluster = Text.readString(in);
   }
 
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/RecordCategory.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/RecordCategory.java
@@ -1,0 +1,6 @@
+package com.twitter.hraven;
+
+public enum RecordCategory {
+  HISTORY_COUNTER, HISTORY_META, HISTORY_TASK_COUNTER, HISTORY_TASK_META, CONF, CONF_META, META,
+  INFERRED
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/RecordDataKey.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/RecordDataKey.java
@@ -1,0 +1,82 @@
+package com.twitter.hraven;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.io.ArrayWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.StringUtils;
+
+public class RecordDataKey implements Writable {
+  private List<String> components;
+
+  public RecordDataKey(String... components) {
+    this.components = Arrays.asList(components);
+  }
+
+  public RecordDataKey(String firstComponent) {
+    this.components = new ArrayList<String>();
+    this.components.add(firstComponent);
+  }
+
+  public void add(String component) {
+    this.components.add(component);
+  }
+
+  public String get(int index) {
+    return components.get(index);
+  }
+
+  public List<String> getComponents() {
+    return components;
+  }
+
+  @Override
+  public int hashCode() {
+    return 1 + ((components == null) ? 0 : components.hashCode());
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    RecordDataKey other = (RecordDataKey) obj;
+    if (components == null) {
+      if (other.components != null) {
+        return false;
+      }
+    } else if (!components.equals(other.components)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public String toString() {
+    return StringUtils.join(Constants.PERIOD_SEP_CHAR, components);
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    new ArrayWritable((String[])this.components.toArray()).write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    ArrayWritable a = new ArrayWritable(Text.class);
+    a.readFields(in);
+    this.components = Arrays.asList(a.toStrings());
+  }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/TaskKey.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/TaskKey.java
@@ -15,12 +15,17 @@ limitations under the License.
 */
 package com.twitter.hraven;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparable;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
-
 
 /**
  * Represents the row key for an individual job task.  This key shares all the
@@ -32,7 +37,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 @JsonSerialize(
     include=JsonSerialize.Inclusion.NON_NULL
   )
-public class TaskKey extends JobKey implements Comparable<Object> {
+public class TaskKey extends JobKey implements WritableComparable<Object> {
   private String taskId;
 
   @JsonCreator
@@ -82,5 +87,17 @@ public class TaskKey extends JobKey implements Comparable<Object> {
 	  return new HashCodeBuilder().appendSuper(super.hashCode())
           .append(this.taskId)
           .toHashCode();
+  }
+  
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    Text.writeString(out, this.taskId);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    this.taskId = Text.readString(in);
   }
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
@@ -551,4 +551,8 @@ public class JobHistoryRawService {
     byte[] jobHistoryRaw = keyValue.getValue();
     return jobHistoryRaw;
   }
+
+  public HTable getTable() {
+	return rawTable;
+  }
 }

--- a/hraven-core/src/main/java/com/twitter/hraven/util/EnumWritable.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/EnumWritable.java
@@ -1,0 +1,32 @@
+package com.twitter.hraven.util;
+
+import java.io.*;
+import org.apache.hadoop.io.*;
+
+public class EnumWritable<E extends Enum<E>> implements WritableComparable<E> {
+    private Class<E> cls;
+    private E value;
+
+    @SuppressWarnings("unchecked")
+    public EnumWritable(E value) {
+        this.cls = (Class<E>) value.getClass();
+        this.value = value;
+    }
+
+    public E getValue() {
+        return value;
+    }
+
+    public void readFields(DataInput input) throws IOException {
+        value = WritableUtils.readEnum(input, cls);
+    }
+
+    public void write(DataOutput output) throws IOException {
+        WritableUtils.writeEnum(output, value);
+    }
+
+    @Override
+    public int compareTo(E o) {
+      return this.value.compareTo(o);
+    }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/util/Serializer.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/Serializer.java
@@ -1,0 +1,22 @@
+package com.twitter.hraven.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class Serializer {
+    public static byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        ObjectOutputStream o = new ObjectOutputStream(b);
+        o.writeObject(obj);
+        return b.toByteArray();
+    }
+
+    public static Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        ByteArrayInputStream b = new ByteArrayInputStream(bytes);
+        ObjectInputStream o = new ObjectInputStream(b);
+        return o.readObject();
+    }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/util/StringUtil.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/StringUtil.java
@@ -36,6 +36,7 @@ public class StringUtil {
   public static String cleanseToken(String token) {
     if (token == null || token.length() == 0) { return token; };
 
+    token = token.trim();
     String cleansed = token.replaceAll(SPACE, UNDERSCORE);
     cleansed = cleansed.replaceAll(Constants.SEP, UNDERSCORE);
 

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParser.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParser.java
@@ -15,8 +15,7 @@ limitations under the License.
  */
 package com.twitter.hraven.etl;
 
-import java.util.List;
-import org.apache.hadoop.hbase.client.Put;
+import java.util.Collection;
 import com.twitter.hraven.JobKey;
 import com.twitter.hraven.datasource.ProcessingException;
 
@@ -48,16 +47,16 @@ public interface JobHistoryFileParser {
 	 * Return the generated list of job puts assembled when history file is
 	 * parsed
 	 * 
-	 * @return a list of jobPuts
+	 * @return a collection of JobHistoryRecords
 	 */
-	public List<Put> getJobPuts();
+	public Collection getJobRecords();
 
 	/**
 	 * Return the generated list of task puts assembled when history file is
 	 * parsed
 	 * 
-	 * @return a list of taskPuts
+	 * @return a list of JobHistoryTaskRecords
 	 */
-	public List<Put> getTaskPuts();
+	public Collection getTaskRecords();
 
 }

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParserBase.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParserBase.java
@@ -19,12 +19,15 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import com.twitter.hraven.Constants;
 import com.twitter.hraven.HadoopVersion;
 import com.twitter.hraven.JobHistoryKeys;
+import com.twitter.hraven.JobHistoryRecord;
+import com.twitter.hraven.JobKey;
+import com.twitter.hraven.RecordCategory;
+import com.twitter.hraven.RecordDataKey;
 import com.twitter.hraven.datasource.ProcessingException;
 import com.twitter.hraven.util.ByteUtil;
 
@@ -54,15 +57,12 @@ public abstract class JobHistoryFileParserBase implements JobHistoryFileParser {
 	 * 
 	 * @return Put
 	 */
-	public Put getHadoopVersionPut(HadoopVersion historyFileVersion, byte[] jobKeyBytes) {
-	  Put pVersion = new Put(jobKeyBytes);
-	  byte[] valueBytes = null;
-	  valueBytes = Bytes.toBytes(historyFileVersion.toString());
-	  byte[] qualifier = Bytes.toBytes(JobHistoryKeys.hadoopversion.toString().toLowerCase());
-	  pVersion.add(Constants.INFO_FAM_BYTES, qualifier, valueBytes);
-	  return pVersion;
+	public JobHistoryRecord getHadoopVersionRecord(HadoopVersion historyFileVersion, JobKey jobKey) {
+		return new JobHistoryRecord(RecordCategory.HISTORY_META, jobKey,
+				new RecordDataKey(JobHistoryKeys.hadoopversion.toString()
+						.toLowerCase()), historyFileVersion.toString());
 	}
-
+	
   /**
    * extract the string around Xmx in the java child opts " -Xmx1024m -verbose:gc"
    * @param javaChildOptsStr

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParserHadoop1.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParserHadoop1.java
@@ -17,6 +17,7 @@ package com.twitter.hraven.etl;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -25,6 +26,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.mapred.JobHistoryCopy;
 import com.twitter.hraven.Constants;
+import com.twitter.hraven.JobHistoryRecordCollection;
+import com.twitter.hraven.JobHistoryRecord;
 import com.twitter.hraven.JobKey;
 import com.twitter.hraven.datasource.ProcessingException;
 import com.twitter.hraven.mapreduce.JobHistoryListener;
@@ -56,9 +59,9 @@ public class JobHistoryFileParserHadoop1 extends JobHistoryFileParserBase {
 			jobHistoryListener = new JobHistoryListener(jobKey);
 			JobHistoryCopy.parseHistoryFromIS(new ByteArrayInputStream(historyFile), jobHistoryListener);
 			// set the hadoop version for this record
-			Put versionPut = getHadoopVersionPut(JobHistoryFileParserFactory.getHistoryFileVersion1(), 
-			  jobHistoryListener.getJobKeyBytes());
-			jobHistoryListener.includeHadoopVersionPut(versionPut);
+			JobHistoryRecord versionRecord = getHadoopVersionRecord(JobHistoryFileParserFactory.getHistoryFileVersion1(), 
+			jobHistoryListener.getJobKey());
+			jobHistoryListener.includeHadoopVersionRecord(versionRecord);
 		} catch (IOException ioe) {
 			LOG.error(" Exception during parsing hadoop 1.0 file ", ioe);
 			throw new ProcessingException(
@@ -72,9 +75,9 @@ public class JobHistoryFileParserHadoop1 extends JobHistoryFileParserBase {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public List<Put> getJobPuts() {
+	public Collection getJobRecords() {
 		if (jobHistoryListener != null) {
-			return jobHistoryListener.getJobPuts();
+			return jobHistoryListener.getJobRecords();
 		} else {
 			return null;
 		}
@@ -84,9 +87,9 @@ public class JobHistoryFileParserHadoop1 extends JobHistoryFileParserBase {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public List<Put> getTaskPuts() {
+	public Collection getTaskRecords() {
 		if (jobHistoryListener != null) {
-			return jobHistoryListener.getTaskPuts();
+			return jobHistoryListener.getTaskRecords();
 		} else {
 			return null;
 		}

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
@@ -148,10 +148,10 @@ public class ProcessRecordService {
    *         state.
    * @throws IOException
    */
-  public ProcessRecord getLastSuccessfulProcessRecord(String cluster)
+  public ProcessRecord getLastSuccessfulProcessRecord(String cluster, String processFileSubstring)
       throws IOException {
     List<ProcessRecord> processRecords = getProcessRecords(cluster, NOT_EQUAL,
-        CREATED, 1, null);
+        CREATED, 1, processFileSubstring);
     if (processRecords.size() > 0) {
       return processRecords.get(0);
     }

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/Sink.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/Sink.java
@@ -1,0 +1,33 @@
+package com.twitter.hraven.etl;
+
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.lib.output.MultipleOutputs;
+import com.twitter.hraven.mapreduce.GraphiteOutputFormat;
+import com.twitter.hraven.mapreduce.HbaseOutputFormat;
+import com.twitter.hraven.mapreduce.JobFileTableMapper;
+
+public enum Sink {
+
+  HBASE {
+
+    @Override
+    public void configureJob(Job job) {
+      MultipleOutputs.addNamedOutput(job, name(), HbaseOutputFormat.class,
+        JobFileTableMapper.getOutputKeyClass(), JobFileTableMapper.getOutputValueClass());
+    }
+
+  },
+
+  GRAPHITE {
+
+    @Override
+    public void configureJob(Job job) {
+      MultipleOutputs.addNamedOutput(job, name(), GraphiteOutputFormat.class,
+        JobFileTableMapper.getOutputKeyClass(), JobFileTableMapper.getOutputValueClass());
+    }
+
+  };
+
+  public abstract void configureJob(Job job);
+
+}

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/GraphiteHistoryWriter.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/GraphiteHistoryWriter.java
@@ -1,0 +1,366 @@
+package com.twitter.hraven.mapreduce;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import com.kenai.jffi.Array;
+import com.twitter.hraven.Constants;
+import com.twitter.hraven.Framework;
+import com.twitter.hraven.HravenService;
+import com.twitter.hraven.JobHistoryKeys;
+import com.twitter.hraven.JobHistoryRecordCollection;
+import com.twitter.hraven.JobHistoryRecord;
+import com.twitter.hraven.JobKey;
+import com.twitter.hraven.RecordCategory;
+import com.twitter.hraven.RecordDataKey;
+import com.twitter.hraven.datasource.JobKeyConverter;
+import com.twitter.hraven.util.ByteUtil;
+
+public class GraphiteHistoryWriter {
+
+  private static Log LOG = LogFactory.getLog(GraphiteHistoryWriter.class);
+
+  private final Pattern APPID_PATTERN_OOZIE_LAUNCHER = Pattern.compile("oozie:launcher:T=(.*):W=(.*):A=(.*):ID=(.*)");
+  private final Pattern APPID_PATTERN_OOZIE_ACTION = Pattern.compile("oozie:action:T=(.*):W=(.*):A=(.*):ID=[0-9]{7}-[0-9]{15}-oozie-oozi-W(.*)");
+  private final Pattern APPID_PATTERN_PIGJOB = Pattern.compile("PigLatin:(.*).pig");
+  private static final String GRAPHITE_KEY_FILTER = "[./\\\\\\s,]";
+  private static final int PIG_ALIAS_FINGERPRINT_LENGTH = 100;
+  
+  private static final String submitTimeKey = JobHistoryKeys.SUBMIT_TIME.toString();
+  private static final String launchTimeKey = JobHistoryKeys.LAUNCH_TIME.toString();
+  private static final String finishTimeKey = JobHistoryKeys.FINISH_TIME.toString();
+  private static final String totalTimeKey = "total_time";
+  private static final String runTimeKey = "run_time";
+
+  private HravenService service;
+  private JobHistoryRecordCollection recordCollection;
+  private String prefix;
+  private StringBuilder lines;
+  private List<String> userFilter;
+  private List<String> queueFilter;
+  private List<String> excludedComponents;
+  private List<String> doNotExcludeApps;
+  
+  private HTable keyMappingTable;
+  private HTable reverseKeyMappingTable;
+
+  /**
+   * Writes a single {@link JobHistoryRecord} to the specified {@link HravenService} Passes the
+   * large multi record of which this record is a part of, so that we can get other contextual
+   * attributes to use in the graphite metric naming scheme
+   * @param graphiteKeyMappingTable 
+   * @param serviceKey
+   * @param userFilter 
+   * @param doNotExcludeApps 
+   * @param jobRecord
+   * @param multiRecord
+   * @throws IOException
+   * @throws InterruptedException
+   */
+
+  public GraphiteHistoryWriter(HTable keyMappingTable, HTable reverseKeyMappingTable, String prefix, HravenService serviceKey,
+      JobHistoryRecordCollection recordCollection, StringBuilder sb, String userFilter, String queueFilter, String excludedComponents, String doNotExcludeApps) {
+    this.keyMappingTable = keyMappingTable;
+    this.reverseKeyMappingTable = reverseKeyMappingTable;
+    this.service = serviceKey;
+    this.recordCollection = recordCollection;
+    this.prefix = prefix;
+    this.lines = sb;
+    if (StringUtils.isNotEmpty(userFilter))
+      this.userFilter = Arrays.asList(userFilter.split(","));
+    if (StringUtils.isNotEmpty(queueFilter))
+      this.queueFilter = Arrays.asList(queueFilter.split(","));
+    if (StringUtils.isNotEmpty(excludedComponents))
+      this.excludedComponents = Arrays.asList(excludedComponents.split(","));
+    if (StringUtils.isNotEmpty(doNotExcludeApps))
+      this.doNotExcludeApps = Arrays.asList(doNotExcludeApps.split(","));
+  }
+
+  public int write() throws IOException {
+    /*
+     * Send metrics in the format {PREFIX}.{cluster}.{user}.{appId}.{subAppId} {value}
+     * {submit_time} subAppId is formed differently for each framework. For pig, its the alias
+     * names and feature used in the job. appId will be parsed with a bunch of known patterns
+     * (oozie launcher jobs, pig jobs, etc.)
+     */
+
+    int lineCount = 0;
+    
+    boolean inDoNotExcludeApps = false;
+    
+    if (doNotExcludeApps != null) {
+      for (String appStr: this.doNotExcludeApps) {
+        if (recordCollection.getKey().getAppId().indexOf(appStr) != -1) {
+          inDoNotExcludeApps = true;
+          break;
+        }
+      }  
+    }
+    
+    if ( 
+        // exclude from further filters if appId matches list of doNotExcludeApps substrings
+        inDoNotExcludeApps ||
+        
+        // or it must pass the user and queue filters, if not null 
+        ( (userFilter == null || userFilter.contains(recordCollection.getKey().getUserName())) &&
+         (queueFilter == null || queueFilter.contains(recordCollection.getValue(RecordCategory.CONF_META,
+                                                                           new RecordDataKey(Constants.HRAVEN_QUEUE)))) )
+      ) {
+      
+      Framework framework = getFramework(recordCollection);
+      String metricsPathPrefix;
+
+      String pigAliasFp = getPigAliasFingerprint(recordCollection);
+      String genAppId = genAppId(recordCollection, recordCollection.getKey().getAppId());
+      
+      if (genAppId == null) {
+        genAppId = recordCollection.getKey().getAppId();
+        LOG.error("Generated appId is null for app " + recordCollection.getKey().toString());
+      }
+      
+      if (framework == Framework.PIG && pigAliasFp != null) {
+        // TODO: should ideally include app version too, but PIG-2587's pig.logical.plan.signature
+        // which hraven uses was available only from pig 0.11
+        
+        metricsPathPrefix =
+            generatePathPrefix(prefix,
+                              recordCollection.getKey().getCluster(),
+                              recordCollection.getKey().getUserName(),
+                              genAppId,
+                              pigAliasFp)
+                              .toString();
+      } else {
+        metricsPathPrefix =
+            generatePathPrefix(prefix,
+                              recordCollection.getKey().getCluster(),
+                              recordCollection.getKey().getUserName(),
+                              genAppId)
+                              .toString();
+      }
+      
+      try {
+        storeAppIdMapping(metricsPathPrefix);
+      } catch (IOException e) {
+        LOG.error("Failed to store mapping for app " + recordCollection.getKey().getAppId()
+            + " to '" + metricsPathPrefix + "'");
+      }
+
+      // Round the timestamp to second as Graphite accepts it in such
+      // a format.
+      int timestamp = Math.round(recordCollection.getSubmitTime() / 1000);
+      
+      // For now, relies on receiving job history and job conf as part of the same
+      // JobHistoryMultiRecord
+      for (JobHistoryRecord jobRecord : recordCollection) {
+        if (service == HravenService.JOB_HISTORY
+            && (jobRecord.getDataCategory() == RecordCategory.HISTORY_COUNTER || jobRecord
+                .getDataCategory() == RecordCategory.INFERRED)
+            && !(jobRecord.getDataKey().get(0).equalsIgnoreCase(submitTimeKey)
+                || jobRecord.getDataKey().get(0).equalsIgnoreCase(launchTimeKey) || jobRecord.getDataKey()
+                .get(0).equalsIgnoreCase(finishTimeKey))) {
+
+          StringBuilder line = new StringBuilder();
+          line.append(metricsPathPrefix);
+
+          boolean ignoreRecord = false;
+          for (String comp : jobRecord.getDataKey().getComponents()) {
+            if (excludedComponents != null && excludedComponents.contains(comp)) {
+              ignoreRecord = true;
+              LOG.info("Excluding component '" + jobRecord.getDataKey().toString() + "' of app " + jobRecord.getKey().toString());
+              break;
+            }
+            line.append(".").append(sanitize(comp));
+          }
+          
+          if (ignoreRecord)
+            continue;
+          else
+            lineCount++;
+
+          line.append(" ").append(jobRecord.getDataValue()).append(" ")
+              .append(timestamp).append("\n");
+          lines.append(line);
+        }
+      }
+      
+      //handle run times
+      Long finishTime = (Long)recordCollection.getValue(RecordCategory.HISTORY_COUNTER, new RecordDataKey(finishTimeKey));
+      if (finishTime == null)
+        finishTime = (Long)recordCollection.getValue(RecordCategory.HISTORY_COUNTER, new RecordDataKey(finishTimeKey.toLowerCase()));
+      Long launchTime = (Long)recordCollection.getValue(RecordCategory.HISTORY_COUNTER, new RecordDataKey(launchTimeKey));
+      if (launchTime == null)
+        launchTime = (Long)recordCollection.getValue(RecordCategory.HISTORY_COUNTER, new RecordDataKey(launchTimeKey.toLowerCase()));
+      
+      if (finishTime != null && recordCollection.getSubmitTime() != null) {
+        lines.append(metricsPathPrefix + ".").append(totalTimeKey + " " + (finishTime-recordCollection.getSubmitTime()) + " " + timestamp + "\n");
+        lineCount++;
+      }
+      
+      if (finishTime != null && launchTime != null) {
+        lines.append(metricsPathPrefix + ".").append(runTimeKey + " " + (finishTime-launchTime) + " " + timestamp + "\n");
+        lineCount++;
+      }
+    }
+    
+    return lineCount;
+  }
+
+  private void storeAppIdMapping(String metricsPathPrefix) throws IOException {
+    Put put = new Put(new JobKeyConverter().toBytes(recordCollection.getKey()));
+    put.add(Constants.INFO_FAM_BYTES, Constants.GRAPHITE_KEY_MAPPING_COLUMN_BYTES, Bytes.toBytes(metricsPathPrefix));
+    keyMappingTable.put(put);
+    
+    put = new Put(Bytes.toBytes(metricsPathPrefix));
+    
+    byte[] appIdBytes = ByteUtil.join(Constants.SEP_BYTES,
+      Bytes.toBytes(recordCollection.getKey().getCluster()),
+      Bytes.toBytes(recordCollection.getKey().getUserName()),
+      Bytes.toBytes(recordCollection.getKey().getAppId()));
+      
+    put.add(Constants.INFO_FAM_BYTES, Constants.GRAPHITE_KEY_MAPPING_COLUMN_BYTES, appIdBytes);
+    reverseKeyMappingTable.put(put);
+  }
+
+  private String getPigAliasFingerprint(JobHistoryRecordCollection recordCollection) {
+    Object aliasRec = recordCollection.getValue(RecordCategory.CONF, new RecordDataKey("pig.alias"));
+    Object featureRec = recordCollection.getValue(RecordCategory.CONF, new RecordDataKey("pig.job.feature"));
+
+    String alias = null;
+    String feature = null;
+
+    if (aliasRec != null) {
+      alias = (String) aliasRec;
+    }
+
+    if (featureRec != null) {
+      feature = (String) featureRec;
+    }
+
+    if (alias != null) {
+      return (feature != null ? feature + ":" : "")
+          + StringUtils.abbreviate(alias, PIG_ALIAS_FINGERPRINT_LENGTH);
+    }
+
+    return null;
+  }
+
+  private String genAppId(JobHistoryRecordCollection recordCollection, String appId) {
+    String oozieActionName = getOozieActionName(recordCollection);
+
+    if (getFramework(recordCollection) == Framework.PIG && APPID_PATTERN_PIGJOB.matcher(appId).matches()) {
+      // pig:{oozie-action-name}:{pigscript}
+      if (oozieActionName != null) {
+        appId = APPID_PATTERN_PIGJOB.matcher(appId).replaceAll("pig:" + oozieActionName + ":$1");
+      } else {
+        appId = APPID_PATTERN_PIGJOB.matcher(appId).replaceAll("pig:$1");
+      }
+    } else if (APPID_PATTERN_OOZIE_LAUNCHER.matcher(appId).matches()) {
+      // ozl:{oozie-workflow-name}
+      appId = APPID_PATTERN_OOZIE_LAUNCHER.matcher(appId).replaceAll("ozl:$1:$2:$3");
+    } else if (APPID_PATTERN_OOZIE_ACTION.matcher(appId).matches()) {
+      // oza:{oozie-workflow-name}:{oozie-action-name}
+      appId = APPID_PATTERN_OOZIE_ACTION.matcher(appId).replaceAll("oza:$1:$2:$3:$4");
+    }
+
+    return appId;
+  }
+
+  private Framework getFramework(JobHistoryRecordCollection recordCollection) {
+    Object rec =
+        recordCollection.getValue(RecordCategory.CONF_META, new RecordDataKey(Constants.FRAMEWORK_COLUMN));
+
+    if (rec != null) {
+      return Framework.valueOf((String) rec);
+    }
+
+    return null;
+  }
+
+  private String getOozieActionName(JobHistoryRecordCollection recordCollection) {
+    Object rec = recordCollection.getValue(RecordCategory.CONF, new RecordDataKey("oozie.action.id"));
+
+    if (rec != null) {
+      String actionId = ((String) rec);
+      return actionId.substring(actionId.indexOf("@") + 1, actionId.length());
+    }
+
+    return null;
+  }
+
+  /**
+   * Util method to generate metrix path prefix
+   * @return
+   * @throws UnsupportedEncodingException
+   */
+
+  private StringBuilder generatePathPrefix(String... args) {
+    StringBuilder prefix = new StringBuilder();
+    boolean first = true;
+    for (String arg : args) {
+      if (!first) {
+        prefix.append(".");
+      }
+
+      prefix.append(sanitize(arg));
+      first = false;
+    }
+    return prefix;
+  }
+
+  /**
+   * Util method to sanitize metrics for sending to graphite E.g. remove periods ("."), etc.
+   * @throws UnsupportedEncodingException
+   */
+  public static String sanitize(String s) {
+    return s.replaceAll(GRAPHITE_KEY_FILTER, "_");
+  }
+
+  /**
+   * Output the {@link JobHistoryRecord} received in debug log
+   * @param serviceKey
+   * @param jobRecord
+   */
+
+  public static void logRecord(HravenService serviceKey, JobHistoryRecord jobRecord) {
+    StringBuilder line = new StringBuilder();
+    String seperator = ", ";
+    String seperator2 = "|";
+
+    line.append("Service: " + serviceKey.name());
+
+    JobKey key = jobRecord.getKey();
+    line.append(seperator).append("Cluster: " + key.getCluster());
+    line.append(seperator).append("User: " + key.getUserName());
+    line.append(seperator).append("AppId: " + key.getAppId());
+    line.append(seperator).append("RunId: " + key.getRunId());
+    line.append(seperator).append("JobId: " + key.getJobId());
+
+    line.append(seperator2);
+    line.append(seperator).append("Category: " + jobRecord.getDataCategory().name());
+
+    line.append(seperator).append("Key: ");
+    for (String comp : jobRecord.getDataKey().getComponents()) {
+      line.append(comp).append(".");
+    }
+
+    line.append(seperator).append("Value: " + jobRecord.getDataValue());
+    line.append(seperator).append("SubmitTime: " + jobRecord.getSubmitTime());
+
+    LOG.debug(line);
+  }
+}

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/GraphiteOutputFormat.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/GraphiteOutputFormat.java
@@ -1,0 +1,198 @@
+package com.twitter.hraven.mapreduce;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
+import java.net.Socket;
+import java.net.URLEncoder;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import com.twitter.hraven.Constants;
+import com.twitter.hraven.HravenRecord;
+import com.twitter.hraven.HravenService;
+import com.twitter.hraven.JobHistoryRecordCollection;
+import com.twitter.hraven.JobHistoryRecord;
+import com.twitter.hraven.JobKey;
+import com.twitter.hraven.RecordCategory;
+import com.twitter.hraven.util.EnumWritable;
+
+/**
+ * @author angad.singh {@link OutputFormat} for sending metrics to graphite
+ */
+
+public class GraphiteOutputFormat extends OutputFormat<EnumWritable<HravenService>, HravenRecord> {
+
+  private static Log LOG = LogFactory.getLog(GraphiteOutputFormat.class);
+  private static Writer writer;
+
+  /**
+   * {@link OutputCommitter} which does nothing
+   */
+  protected static class GraphiteOutputCommitter extends OutputCommitter {
+
+    @Override
+    public void setupJob(JobContext jobContext) throws IOException {
+    }
+
+    @Override
+    public void setupTask(TaskAttemptContext taskContext) throws IOException {
+    }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext taskContext) throws IOException {
+      return false;
+    }
+
+    @Override
+    public void commitTask(TaskAttemptContext taskContext) throws IOException {
+    }
+
+    @Override
+    public void abortTask(TaskAttemptContext taskContext) throws IOException {
+    }
+
+  }
+
+  protected static class GraphiteRecordWriter extends RecordWriter<EnumWritable<HravenService>, HravenRecord> {
+
+    // prepend this prefix to all metrics
+    private String METRIC_PREFIX;
+    
+    // filter jobs not submitted by this user
+    private String userFilter;
+    
+    // filter jobs not submitted in this queue
+    private String queueFilter;
+    
+    // exclude these metric path components (e.g MultiInputCounters - create a lot of redundant tree
+    // paths, and you wouldn't want to send them to graphite)
+    private String excludedComponents;
+    
+    // comma seperated list of app substrings to prevent from being excluded after above filters
+    private String doNotExcludeApps;
+    
+    private HTable keyMappingTable;
+    private HTable reverseKeyMappingTable;
+    
+
+    public GraphiteRecordWriter(Configuration hbaseconfig, String host, int port, String prefix, String userFilter, String queueFilter, String excludedComponents, String doNotExcludeApps) throws IOException {
+      this.METRIC_PREFIX = prefix;
+      this.userFilter = userFilter;
+      this.queueFilter = queueFilter;
+      this.excludedComponents = excludedComponents;
+      this.doNotExcludeApps = doNotExcludeApps;
+      
+      keyMappingTable = new HTable(hbaseconfig, Constants.GRAPHITE_KEY_MAPPING_TABLE_BYTES);
+      keyMappingTable.setAutoFlush(false);
+
+      reverseKeyMappingTable = new HTable(hbaseconfig, Constants.GRAPHITE_REVERSE_KEY_MAPPING_TABLE_BYTES);
+      reverseKeyMappingTable.setAutoFlush(false);
+
+      try {
+        // Open an connection to Graphite server.
+        Socket socket = new Socket(host, port);
+        writer = new OutputStreamWriter(socket.getOutputStream());
+      } catch (Exception e) {
+        throw new IOException("Error connecting to graphite, " + host + ":" + port, e);
+      }
+    }
+
+    /**
+     * Split a {@link JobHistoryRecordCollection} into {@link JobHistoryRecord}s and call the
+     * {@link #writeRecord(HravenService, JobHistoryRecord)} method
+     */
+
+    @Override
+    public void write(EnumWritable<HravenService> serviceKey, HravenRecord value) throws IOException,
+        InterruptedException {
+      HravenService service = serviceKey.getValue();
+      JobHistoryRecordCollection recordCollection;
+
+      if (value instanceof JobHistoryRecordCollection) {
+        recordCollection = (JobHistoryRecordCollection) value;
+      } else {
+        recordCollection = new JobHistoryRecordCollection((JobHistoryRecord) value);
+      }
+
+      StringBuilder output = new StringBuilder();
+      int lines = 0;
+
+      try {
+        GraphiteHistoryWriter graphiteWriter =
+            new GraphiteHistoryWriter(keyMappingTable, reverseKeyMappingTable, METRIC_PREFIX, service, recordCollection, output, userFilter, queueFilter, excludedComponents, doNotExcludeApps);
+        lines = graphiteWriter.write();
+      } catch (Exception e) {
+        LOG.error("Error generating metrics for graphite", e);
+      }
+
+      if (output.length() > 0) {
+        
+        try {
+          LOG.info("SendToGraphite: " + recordCollection.getKey().toString() + " : " + lines + " metrics");
+          writer.write(output.toString());
+        } catch (Exception e) {
+          LOG.error("Error sending metrics to graphite", e);
+          throw new IOException("Error sending metrics", e);
+        }  
+      }
+    }
+
+    @Override
+    public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+      try {
+        LOG.info("flushing records and closing writer");
+        writer.close();
+      } catch (Exception e) {
+        throw new IOException("Error flush metrics to graphite", e);
+      }
+      keyMappingTable.close();
+      reverseKeyMappingTable.close();
+    }
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext arg0) throws IOException, InterruptedException {
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException,
+      InterruptedException {
+    return new GraphiteOutputCommitter();
+  }
+
+  /**
+   * Output a custom {@link GraphiteRecordWriter} to send metrics to graphite
+   */
+  @Override
+  public RecordWriter<EnumWritable<HravenService>, HravenRecord> getRecordWriter(TaskAttemptContext context)
+      throws IOException, InterruptedException {
+    Configuration conf = context.getConfiguration();
+    return new GraphiteRecordWriter(HBaseConfiguration.create(conf),
+                                    conf.get(Constants.JOBCONF_GRAPHITE_HOST_KEY, Constants.GRAPHITE_DEFAULT_HOST),
+                                    conf.getInt(Constants.JOBCONF_GRAPHITE_PORT_KEY, Constants.GRAPHITE_DEFAULT_PORT),
+                                    conf.get(Constants.JOBCONF_GRAPHITE_PREFIX, Constants.GRAPHITE_DEFAULT_PREFIX),
+                                    conf.get(Constants.JOBCONF_GRAPHITE_USER_FILTER),
+                                    conf.get(Constants.JOBCONF_GRAPHITE_QUEUE_FILTER),
+                                    conf.get(Constants.JOBCONF_GRAPHITE_EXCLUDED_COMPONENTS),
+                                    conf.get(Constants.JOBCONF_GRAPHITE_DONOTEXCLUDE_APPS)
+                                    );
+  }
+
+}

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/HbaseHistoryWriter.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/HbaseHistoryWriter.java
@@ -1,0 +1,105 @@
+package com.twitter.hraven.mapreduce;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.util.Bytes;
+import com.twitter.hraven.Constants;
+import com.twitter.hraven.HravenRecord;
+import com.twitter.hraven.JobHistoryKeys;
+import com.twitter.hraven.JobHistoryRecord;
+import com.twitter.hraven.RecordCategory;
+import com.twitter.hraven.datasource.ProcessingException;
+
+public class HbaseHistoryWriter {
+  private static Log LOG = LogFactory.getLog(HbaseHistoryWriter.class);
+  
+  public static void addHistoryPuts(HravenRecord record, Put p) {
+    byte[] family = Constants.INFO_FAM_BYTES;
+
+    JobHistoryKeys dataKey = null;
+    if (record.getDataKey() != null && record.getDataKey().get(0) != null)
+      try {
+        dataKey = JobHistoryKeys.valueOf(record.getDataKey().get(0));        
+      } catch (IllegalArgumentException e) {
+        // some keys other than JobHistoryKeys were added by
+        // JobHistoryListener. Ignore this exception.
+      }
+
+    if (dataKey == null) {
+      byte[] qualifier = null;
+      if (record.getDataCategory() == RecordCategory.CONF) {
+        byte[] jobConfColumnPrefix =
+            Bytes.add(Constants.JOB_CONF_COLUMN_PREFIX_BYTES, Constants.SEP_BYTES);
+        qualifier = Bytes.add(jobConfColumnPrefix, Bytes.toBytes(record.getDataKey().toString()));
+      } else {
+        qualifier = Bytes.toBytes(record.getDataKey().toString().toLowerCase());
+      }
+
+      byte[] valueBytes = null;
+      
+      if (record.getDataValue() instanceof Long) {
+        valueBytes = Bytes.toBytes((Long)record.getDataValue());
+      } else if (record.getDataValue() instanceof Double) {
+        valueBytes = Bytes.toBytes((Double)record.getDataValue());
+      } else {
+        valueBytes = Bytes.toBytes(record.getDataValue().toString());
+      }
+      
+      Bytes.toBytes(record.getDataValue().toString());
+      p.add(family, qualifier, valueBytes);
+    } else if (dataKey == JobHistoryKeys.COUNTERS || dataKey == JobHistoryKeys.MAP_COUNTERS
+        || dataKey == JobHistoryKeys.REDUCE_COUNTERS) {
+
+      String group = record.getDataKey().get(1);
+      String counterName = record.getDataKey().get(2);
+      byte[] counterPrefix = null;
+
+      try {
+        switch (dataKey) {
+        case COUNTERS:
+        case TOTAL_COUNTERS:
+        case TASK_COUNTERS:
+        case TASK_ATTEMPT_COUNTERS:
+          counterPrefix = Bytes.add(Constants.COUNTER_COLUMN_PREFIX_BYTES, Constants.SEP_BYTES);
+          break;
+        case MAP_COUNTERS:
+          counterPrefix = Bytes.add(Constants.MAP_COUNTER_COLUMN_PREFIX_BYTES, Constants.SEP_BYTES);
+        case REDUCE_COUNTERS:
+          counterPrefix =
+              Bytes.add(Constants.REDUCE_COUNTER_COLUMN_PREFIX_BYTES, Constants.SEP_BYTES);
+        default:
+          throw new IllegalArgumentException("Unknown counter type " + dataKey.toString());
+        }
+      } catch (IllegalArgumentException iae) {
+        throw new ProcessingException("Unknown counter type " + dataKey, iae);
+      } catch (NullPointerException npe) {
+        throw new ProcessingException("Null counter type " + dataKey, npe);
+      }
+
+      byte[] groupPrefix = Bytes.add(counterPrefix, Bytes.toBytes(group), Constants.SEP_BYTES);
+      byte[] qualifier = Bytes.add(groupPrefix, Bytes.toBytes(counterName));
+
+      p.add(family, qualifier, Bytes.toBytes((Long) record.getDataValue()));
+    } else {
+      @SuppressWarnings("rawtypes")
+      Class clazz = JobHistoryKeys.KEY_TYPES.get(dataKey);
+      byte[] valueBytes = null;
+
+      if (Integer.class.equals(clazz)) {
+        valueBytes =
+            (Integer) record.getDataValue() == 0 ? Constants.ZERO_INT_BYTES : Bytes
+                .toBytes((Integer) record.getDataValue());
+      } else if (Long.class.equals(clazz)) {
+        valueBytes =
+            (Long) record.getDataValue() == 0 ? Constants.ZERO_LONG_BYTES : Bytes
+                .toBytes((Long) record.getDataValue());
+      } else {
+        // keep the string representation by default
+        valueBytes = Bytes.toBytes((String) record.getDataValue());
+      }
+      byte[] qualifier = Bytes.toBytes(dataKey.toString().toLowerCase());
+      p.add(family, qualifier, valueBytes);
+    }
+  }
+}

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/HbaseOutputFormat.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/HbaseOutputFormat.java
@@ -1,0 +1,130 @@
+package com.twitter.hraven.mapreduce;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.mapreduce.MultiTableOutputFormat;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import com.twitter.hraven.Constants;
+import com.twitter.hraven.HravenRecord;
+import com.twitter.hraven.HravenService;
+import com.twitter.hraven.JobHistoryRecordCollection;
+import com.twitter.hraven.JobHistoryRecord;
+import com.twitter.hraven.JobHistoryTaskRecord;
+import com.twitter.hraven.RecordCategory;
+import com.twitter.hraven.RecordDataKey;
+import com.twitter.hraven.TaskKey;
+import com.twitter.hraven.datasource.JobKeyConverter;
+import com.twitter.hraven.datasource.TaskKeyConverter;
+import com.twitter.hraven.util.EnumWritable;
+
+/**
+ * @author angad.singh Wrapper around Hbase's {@link MultiTableOutputFormat} Converts
+ *         {@link HravenRecords} to Hbase {@link Put}s and writes them to {@link HTable}s
+ *         corresponding to {@link HravenService}
+ */
+
+public class HbaseOutputFormat extends OutputFormat<EnumWritable<HravenService>, HravenRecord> {
+
+  protected static class HravenHbaseRecordWriter extends RecordWriter<EnumWritable<HravenService>, HravenRecord> {
+
+    private RecordWriter<ImmutableBytesWritable, Writable> recordWriter;
+
+    public HravenHbaseRecordWriter(RecordWriter<ImmutableBytesWritable, Writable> recordWriter) {
+      this.recordWriter = recordWriter;
+    }
+
+    /**
+     * Writes a single {@link HravenRecord} to the specified {@link HravenService}
+     * @param serviceKey
+     * @param value
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    private void writeRecord(HravenService serviceKey, HravenRecord value)
+        throws IOException, InterruptedException {
+      ImmutableBytesWritable table = null;
+      Put put = null;
+
+      switch (serviceKey) {
+      case JOB_HISTORY:
+        JobHistoryRecord rec = (JobHistoryRecord) value;
+        put = new Put(new JobKeyConverter().toBytes(rec.getKey()));
+        table = new ImmutableBytesWritable(Constants.HISTORY_TABLE_BYTES);
+        HbaseHistoryWriter.addHistoryPuts(rec, put);
+        break;
+      case JOB_HISTORY_TASK:
+        JobHistoryTaskRecord taskRec = (JobHistoryTaskRecord) value;
+        put = new Put(new TaskKeyConverter().toBytes((TaskKey) taskRec.getKey()));
+        table = new ImmutableBytesWritable(Constants.HISTORY_TASK_TABLE_BYTES);
+        HbaseHistoryWriter.addHistoryPuts(taskRec, put);
+        break;
+      }
+
+      recordWriter.write(table, put);
+    }
+
+    /**
+     * Split a {@link JobHistoryRecordCollection} into {@link JobHistoryRecord}s and call the
+     * {@link #writeRecord(HravenService, JobHistoryRecord)} method
+     */
+
+    @Override
+    public void write(EnumWritable<HravenService> serviceKey, HravenRecord value) throws IOException,
+        InterruptedException {
+      HravenService service = serviceKey.getValue();
+      if (value instanceof JobHistoryRecordCollection) {
+        for (JobHistoryRecord record : (JobHistoryRecordCollection) value) {
+          writeRecord(service, record);
+        }
+      } else {
+        writeRecord(service, value);
+      }
+    }
+
+    @Override
+    public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+      recordWriter.close(context);
+    }
+  }
+
+  private MultiTableOutputFormat outputFormat;
+
+  /**
+   * Wrap around Hbase's {@link MultiTableOutputFormat}
+   */
+  public HbaseOutputFormat() {
+    this.outputFormat = new MultiTableOutputFormat();
+  }
+
+  /**
+   * Wrap around {@link MultiTableOutputFormat}'s {@link MultiTableRecordWriter}
+   */
+  @Override
+  public RecordWriter<EnumWritable<HravenService>, HravenRecord> getRecordWriter(TaskAttemptContext context)
+      throws IOException, InterruptedException {
+    return new HravenHbaseRecordWriter(outputFormat.getRecordWriter(context));
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext context) throws IOException, InterruptedException {
+    outputFormat.checkOutputSpecs(context);
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException,
+      InterruptedException {
+    return outputFormat.getOutputCommitter(context);
+  }
+}

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
@@ -19,9 +19,14 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import javax.annotation.Nullable;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -33,14 +38,23 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.mapreduce.TableMapper;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.lib.output.MultipleOutputs;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
 import com.twitter.hraven.Constants;
+import com.twitter.hraven.HravenRecord;
+import com.twitter.hraven.HravenService;
 import com.twitter.hraven.JobDesc;
 import com.twitter.hraven.JobDescFactory;
+import com.twitter.hraven.JobHistoryRecordCollection;
+import com.twitter.hraven.JobHistoryRecord;
+import com.twitter.hraven.JobHistoryTaskRecord;
 import com.twitter.hraven.JobKey;
 import com.twitter.hraven.QualifiedJobId;
+import com.twitter.hraven.RecordCategory;
+import com.twitter.hraven.RecordDataKey;
 import com.twitter.hraven.datasource.AppVersionService;
 import com.twitter.hraven.datasource.JobHistoryByIdService;
 import com.twitter.hraven.datasource.JobHistoryRawService;
@@ -53,18 +67,21 @@ import com.twitter.hraven.etl.JobHistoryFileParser;
 import com.twitter.hraven.etl.JobHistoryFileParserBase;
 import com.twitter.hraven.etl.JobHistoryFileParserFactory;
 import com.twitter.hraven.etl.ProcessRecordService;
+import com.twitter.hraven.etl.Sink;
+import com.twitter.hraven.util.EnumWritable;
 
 /**
  * Takes in results from a scan from {@link ProcessRecordService
  * @getHistoryRawTableScan}, process both job file and history file and emit out
- * as puts for the {@link Constants#HISTORY_TABLE}
+ * as {@link HravenService}, {@link HravenRecord}. {@link Sink}s will process these
+ * and convert to their respective storage formats
  * <p>
  * As a side-affect we'll load an index record into the
  * {@link Constants#HISTORY_BY_JOBID_TABLE} as well.
  * 
  */
 public class JobFileTableMapper extends
-    TableMapper<ImmutableBytesWritable, Put> {
+    TableMapper<HravenService, HravenRecord> {
 
   private static Log LOG = LogFactory.getLog(JobFileTableMapper.class);
 
@@ -76,6 +93,14 @@ public class JobFileTableMapper extends
       Constants.HISTORY_RAW_TABLE_BYTES);
   private static JobKeyConverter jobKeyConv = new JobKeyConverter();
 
+  private MultipleOutputs mos;
+  
+  /**
+   *  Define the sinks to output to 
+   */
+  
+  private ArrayList<Sink> sinks;
+  
   /**
    * Used to create secondary index.
    */
@@ -96,46 +121,68 @@ public class JobFileTableMapper extends
   /**
    * @return the key class for the job output data.
    */
-  public static Class<? extends WritableComparable<ImmutableBytesWritable>> getOutputKeyClass() {
-    return ImmutableBytesWritable.class;
+  public static Class<?> getOutputKeyClass() {
+    return EnumWritable.class;
   }
 
   /**
    * @return the value class for the job output data.
    */
-  public static Class<? extends Writable> getOutputValueClass() {
-    return Put.class;
+  public static Class<?> getOutputValueClass() {
+    return HravenRecord.class;
   }
 
   @Override
   protected void setup(
-      Mapper<ImmutableBytesWritable, Result, ImmutableBytesWritable, Put>.Context context)
+      Mapper<ImmutableBytesWritable, Result, HravenService, HravenRecord>.Context context)
       throws java.io.IOException, InterruptedException {
     Configuration myConf = context.getConfiguration();
     jobHistoryByIdService = new JobHistoryByIdService(myConf);
     appVersionService = new AppVersionService(myConf);
     rawService = new JobHistoryRawService(myConf);
-
     keyCount = 0;
+
+    sinks =
+        new ArrayList<Sink>(Collections2.transform(Arrays.asList(StringUtils.split(context
+            .getConfiguration().get(Constants.JOBCONF_SINKS), ',')), new Function<String, Sink>() {
+
+          @Override
+          @Nullable
+          public Sink apply(@Nullable String input) {
+            return Sink.valueOf(input);
+          }
+        }));
+
+    mos = new MultipleOutputs<HravenService, HravenRecord>(context);
   }
 
   @Override
   protected void map(
       ImmutableBytesWritable key,
       Result value,
-      Mapper<ImmutableBytesWritable, Result, ImmutableBytesWritable, Put>.Context context)
+      Mapper<ImmutableBytesWritable, Result, HravenService, HravenRecord>.Context context)
       throws java.io.IOException, InterruptedException {
 
     keyCount++;
     boolean success = true;
     QualifiedJobId qualifiedJobId = null;
     try {
+    	
+    	
+      /**
+       *  STEP 0
+       *  
+       *  init and extract meaningful data out of raw value
+       *  
+       *   **/
+    	
       qualifiedJobId = rawService.getQualifiedJobIdFromResult(value);
       context.progress();
 
       Configuration jobConf = rawService.createConfigurationFromResult(value);
       context.progress();
 
+      //figure out submit time
       byte[] jobhistoryraw = rawService.getJobHistoryRawFromResult(value);
       long submitTimeMillis = JobHistoryFileParserBase.getSubmitTimeMillisFromJobHistory(
             jobhistoryraw);
@@ -151,22 +198,29 @@ public class JobFileTableMapper extends
 
       Put submitTimePut = rawService.getJobSubmitTimePut(value.getRow(),
           submitTimeMillis);
-      context.write(RAW_TABLE, submitTimePut);
-
+      
+      rawService.getTable().put(submitTimePut);
+      
+      /** 
+       * STEP 1
+       * 
+       * process and extract job xml/conf
+       * 
+       * **/
       JobDesc jobDesc = JobDescFactory.createJobDesc(qualifiedJobId,
           submitTimeMillis, jobConf);
       JobKey jobKey = new JobKey(jobDesc);
       context.progress();
-
+      
       // TODO: remove sysout
       String msg = "JobDesc (" + keyCount + "): " + jobDesc
           + " submitTimeMillis: " + submitTimeMillis;
       LOG.info(msg);
 
-      List<Put> puts = JobHistoryService.getHbasePuts(jobDesc, jobConf);
+      JobHistoryRecordCollection confRecordCollection = JobHistoryService.getConfRecord(jobDesc, jobConf);
 
-      LOG.info("Writing " + puts.size() + " JobConf puts to "
-          + Constants.HISTORY_TABLE);
+      LOG.info("Sending JobConf records to "
+          + HravenService.JOB_HISTORY + " service");
 
       // TODO:
       // For Scalding just convert the flowID as a Hex number. Use that for the
@@ -176,13 +230,18 @@ public class JobFileTableMapper extends
       // Scan should get the first (lowest job-id) then grab the start-time from
       // the Job.
 
-      // Emit the puts
-      for (Put put : puts) {
-        context.write(JOB_TABLE, put);
-        context.progress();
-      }
+      //1.1 Emit the records for job xml/conf/"JobDesc"
+      //Don't sink config seperately - merge with all other records and then sink
+      //sink(HravenService.JOB_HISTORY, confRecord);
+      context.progress();
 
-      // Write secondary index(es)
+      /** 
+       * STEP 2
+       * 
+       * Write secondary index(es)
+       * 
+       * **/
+      
       LOG.info("Writing secondary indexes");
       jobHistoryByIdService.writeIndexes(jobKey);
       context.progress();
@@ -190,6 +249,14 @@ public class JobFileTableMapper extends
           jobDesc.getAppId(), jobDesc.getVersion(), jobDesc.getRunId());
       context.progress();
 
+      /** 
+       * STEP 3
+       * 
+       * Process and extact actual job history
+       * 
+       * **/
+      
+      //3.1: get job history
       KeyValue keyValue = value.getColumnLatest(Constants.RAW_FAM_BYTES,
        Constants.JOBHISTORY_COL_BYTES);
 
@@ -200,44 +267,25 @@ public class JobFileTableMapper extends
       } else {
         historyFileContents = keyValue.getValue();
       }
+      
+      //3.2: parse job history
       JobHistoryFileParser historyFileParser = JobHistoryFileParserFactory
     		  .createJobHistoryFileParser(historyFileContents, jobConf);
 
       historyFileParser.parse(historyFileContents, jobKey);
       context.progress();
 
-      puts = historyFileParser.getJobPuts();
-      if (puts == null) {
-    	  throw new ProcessingException(
-    			  " Unable to get job puts for this record!" + jobKey);
-      }
-      LOG.info("Writing " + puts.size() + " Job puts to "
-          + Constants.HISTORY_TABLE);
+      //3.3: get and write job related data
+      JobHistoryRecordCollection jobHistoryRecords = (JobHistoryRecordCollection) historyFileParser.getJobRecords();
+      jobHistoryRecords.setSubmitTime(submitTimeMillis);
+      jobHistoryRecords.mergeWith(confRecordCollection);
+      
+      LOG.info("Sending " + jobHistoryRecords.size() + " Job history records to "
+          + HravenService.JOB_HISTORY + " service");
+      
+      context.progress();
 
-      // Emit the puts
-      for (Put put : puts) {
-        context.write(JOB_TABLE, put);
-        // TODO: we should not have to do this, but need to confirm that
-        // TableRecordWriter does this for us.
-        context.progress();
-      }
-
-      puts = historyFileParser.getTaskPuts();
-      if (puts == null) {
-    	  throw new ProcessingException(
-    			  " Unable to get task puts for this record!" + jobKey);
-      }
-      LOG.info("Writing " + puts.size() + " Job puts to "
-          + Constants.HISTORY_TASK_TABLE);
-
-      for (Put put : puts) {
-        context.write(TASK_TABLE, put);
-        // TODO: we should not have to do this, but need to confirm that
-        // TableRecordWriter does this for us.
-        context.progress();
-      }
-
-      /** post processing steps on job puts and job conf puts */
+      //3.4: post processing steps on job records and job conf records
       Long mbMillis = historyFileParser.getMegaByteMillis();
       context.progress();
       if (mbMillis == null) {
@@ -245,21 +293,37 @@ public class JobFileTableMapper extends
               + jobKey);
       }
 
-      Put mbPut = getMegaByteMillisPut(mbMillis, jobKey);
-      LOG.info("Writing mega byte millis  puts to " + Constants.HISTORY_TABLE);
-      context.write(JOB_TABLE, mbPut);
+      JobHistoryRecord mbRecord = getMegaByteMillisRecord(mbMillis, jobKey);
+      LOG.info("Send mega byte millis records to " + HravenService.JOB_HISTORY + " service");
+      
+      jobHistoryRecords.add(mbRecord);
       context.progress();
 
-      /** post processing steps to get cost of the job */
+      //3.5: post processing steps to get cost of the job */
       Double jobCost = getJobCost(mbMillis, context.getConfiguration());
       context.progress();
       if (jobCost == null) {
         throw new ProcessingException(" Unable to get job cost calculation for this record!"
             + jobKey);
       }
-      Put jobCostPut = getJobCostPut(jobCost, jobKey);
-      LOG.info("Writing jobCost puts to " + Constants.HISTORY_TABLE);
-      context.write(JOB_TABLE, jobCostPut);
+      JobHistoryRecord jobCostRecord = getJobCostRecord(jobCost, jobKey);
+      LOG.info("Send jobCost records to " + HravenService.JOB_HISTORY + " service");
+      jobHistoryRecords.add(jobCostRecord);
+      
+      //Sink the merged record
+      sink(HravenService.JOB_HISTORY, jobHistoryRecords);
+      context.progress();
+      
+      //3.6: get and write task related data
+      ArrayList<JobHistoryTaskRecord> taskHistoryRecords = (ArrayList<JobHistoryTaskRecord>) historyFileParser.getTaskRecords();
+      
+      LOG.info("Sending " + taskHistoryRecords.size() + " Task history records to "
+          + HravenService.JOB_HISTORY_TASK + " service");
+
+      for (JobHistoryTaskRecord taskRecord: taskHistoryRecords) {
+        sink(HravenService.JOB_HISTORY_TASK, taskRecord);  
+      }
+      
       context.progress();
 
     } catch (RowKeyParseException rkpe) {
@@ -280,6 +344,12 @@ public class JobFileTableMapper extends
       success = false;
     }
 
+    /**
+     * STEP 4
+     * 
+     * Finalization
+     * 
+     * **/
     if (success) {
       // Update counter to indicate failure.
       HadoopCompat.incrementCounter(context.getCounter(ProcessingCounter.RAW_ROW_SUCCESS_COUNT), 1);
@@ -296,21 +366,28 @@ public class JobFileTableMapper extends
     // row, with one succeeding and one failing, there could be a race where the
     // raw does not properly indicate the true status (which is questionable in
     // any case with multiple simultaneous runs with different outcome).
-    context.write(RAW_TABLE, successPut);
-
+    rawService.getTable().put(successPut);
   }
 
-  /**
-   * generates a put for the megabytemillis
+	private void sink(HravenService service, HravenRecord record)
+			throws IOException, InterruptedException {
+		
+	  for (Sink sink: sinks) {
+	    mos.write(sink.name(), new EnumWritable(service), record);
+	  }
+	}
+
+/**
+   * generates a record for the megabytemillis
    * @param mbMillis
    * @param jobKey
-   * @return the put with megabytemillis
+   * @return the record with megabytemillis
    */
-  private Put getMegaByteMillisPut(Long mbMillis, JobKey jobKey) {
-    Put pMb = new Put(jobKeyConv.toBytes(jobKey));
-    pMb.add(Constants.INFO_FAM_BYTES, Constants.MEGABYTEMILLIS_BYTES, Bytes.toBytes(mbMillis));
-    return pMb;
-  }
+	private JobHistoryRecord getMegaByteMillisRecord(Long mbMillis,
+			JobKey jobKey) {
+		return new JobHistoryRecord(RecordCategory.INFERRED, jobKey,
+				new RecordDataKey(Constants.MEGABYTEMILLIS), mbMillis);
+	}
 
   /**
    * looks for cost file in distributed cache
@@ -400,24 +477,28 @@ public class JobFileTableMapper extends
   }
 
   /**
-   * generates a put for the job cost
+   * generates a record for the job cost
    * @param jobCost
    * @param jobKey
-   * @return the put with job cost
+   * @return the record with job cost
    */
-  private Put getJobCostPut(Double jobCost, JobKey jobKey) {
-    Put pJobCost = new Put(jobKeyConv.toBytes(jobKey));
-    pJobCost.add(Constants.INFO_FAM_BYTES, Constants.JOBCOST_BYTES, Bytes.toBytes(jobCost));
-    return pJobCost;
+  
+  private JobHistoryRecord getJobCostRecord(Double jobCost, JobKey jobKey) {
+	return new JobHistoryRecord(RecordCategory.INFERRED, jobKey,
+			new RecordDataKey(Constants.JOBCOST), jobCost);
   }
 
   @Override
   protected void cleanup(
-      Mapper<ImmutableBytesWritable, Result, ImmutableBytesWritable, Put>.Context context)
+      Mapper<ImmutableBytesWritable, Result, HravenService, HravenRecord>.Context context)
       throws java.io.IOException, InterruptedException {
 
     IOException caught = null;
-
+    
+    //Close the MultipleOutputs instance
+    //to call close on all wrapped OutputFormats's RecordWriters
+    mos.close();
+    
     if (jobHistoryByIdService != null) {
       try {
         jobHistoryByIdService.close();

--- a/hraven-etl/src/test/java/com/twitter/hraven/etl/TestJobHistoryFileParserHadoop1.java
+++ b/hraven-etl/src/test/java/com/twitter/hraven/etl/TestJobHistoryFileParserHadoop1.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 
 import com.google.common.io.Files;
 import com.twitter.hraven.Constants;
+import com.twitter.hraven.JobHistoryRecordCollection;
+import com.twitter.hraven.JobHistoryRecord;
 import com.twitter.hraven.JobKey;
 
 public class TestJobHistoryFileParserHadoop1 {
@@ -64,8 +66,8 @@ public class TestJobHistoryFileParserHadoop1 {
     JobKey jobKey = new JobKey("cluster1", "user1", "Sleep", 1, "job_201311192236_3583");
     historyFileParser.parse(contents, jobKey);
 
-    List<Put> jobPuts = historyFileParser.getJobPuts();
-    assertNotNull(jobPuts);
+    JobHistoryRecordCollection jobRecords = (JobHistoryRecordCollection)historyFileParser.getJobRecords();
+    assertNotNull(jobRecords);
 
     Long mbMillis = historyFileParser.getMegaByteMillis();
     Long expValue = 2981062L;


### PR DESCRIPTION
Generic object model and abstraction for output records of JobFileProcessor's mapper instead of directly emitting Hbase puts at the lowest level of code hierarchy. Used MultipleOutputs to allow sinking to different sinks (graphite, hbase, etc.) and handle specifically writing of records at the sink's OutputFormat level.  Added graphite sink and refactored hbase storage to work as a sink. Changes no hraven behaviour.
