### PR TITLE
glob list instead of simple hdfs list and pattern support for input

### DIFF
--- a/bin/etl/hraven-etl.sh
+++ b/bin/etl/hraven-etl.sh
@@ -40,8 +40,12 @@ costfile=/var/lib/hraven/conf/costFile
 hadoopconfdir=${HADOOP_CONF_DIR:-$HADOOP_HOME/conf}
 hbaseconfdir=${HBASE_CONF_DIR:-$HBASE_HOME/conf}
 # HDFS directories for processing and loading job history data
-historyRawDir=/yarn/history/done/
-historyProcessingDir=/hraven/processing/
+year=2014
+month="*"
+day="*"
+historyDirPattern=/hadoop/mapred/history/done/*/$year/$month/$day/*/*
+historyBasePath=/hadoop/mapred/history/done
+historyProcessingDir=/hadoop/mapred/history/processing/
 #######################################################
 
 #If costfile is empty, fill it with default values
@@ -65,7 +69,7 @@ create_pidfile $HRAVEN_PID_DIR
 trap 'cleanup_pidfile_and_exit $HRAVEN_PID_DIR' INT TERM EXIT
 
 # Pre-process
-$home/jobFilePreprocessor.sh $hadoopconfdir $historyRawDir $historyProcessingDir $cluster $batchsize $defaultrawfilesizelimit
+$home/jobFilePreprocessor.sh $hadoopconfdir $historyBasePath $historyDirPattern $historyProcessingDir $cluster $batchsize $defaultrawfilesizelimit
 
 # Load
 $home/jobFileLoader.sh $hadoopconfdir $mapredmaxsplitsize $schedulerpoolname $cluster $historyProcessingDir

--- a/bin/etl/jobFilePreprocessor.sh
+++ b/bin/etl/jobFilePreprocessor.sh
@@ -19,9 +19,9 @@
 # Usage ./jobFilePreprocessor.sh [hadoopconfdir]
 #   [historyrawdir] [historyprocessingdir] [cluster] [batchsize]
 
-if [ $# -ne 6 ]
+if [ $# -lt 7 ]
 then
-  echo "Usage: `basename $0` [hadoopconfdir] [historyrawdir] [historyprocessingdir] [cluster] [batchsize] [defaultrawfilesizelimit]"
+  echo "Usage: `basename $0` [hadoopconfdir] [historyBasePath] [historyrawdir] [historyprocessingdir] [cluster] [batchsize] [defaultrawfilesizelimit]"
   exit 1
 fi
 
@@ -39,4 +39,4 @@ fi
 create_pidfile $HRAVEN_PID_DIR
 trap 'cleanup_pidfile_and_exit $HRAVEN_PID_DIR' INT TERM EXIT
 
-hadoop --config $1 jar $hravenEtlJar com.twitter.hraven.etl.JobFilePreprocessor -libjars=$LIBJARS -d -i $2 -o $3 -c $4 -b $5 -s $6
+hadoop --config $1 jar $hravenEtlJar com.twitter.hraven.etl.JobFilePreprocessor -libjars=$LIBJARS -d -bi $2 -i $3 -o $4 -c $5 -b $6 -s $7

--- a/hraven-core/src/main/java/com/twitter/hraven/Constants.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/Constants.java
@@ -17,6 +17,8 @@ package com.twitter.hraven;
 
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
+
 import org.apache.hadoop.hbase.util.Bytes;
 
 /**
@@ -426,4 +428,6 @@ public class Constants {
 
   /** name of the properties file used for cluster to cluster identifier mapping */
   public static final String HRAVEN_CLUSTER_PROPERTIES_FILENAME = "hRavenClusters.properties";
+
+  public static final Pattern HADOOPV1HISTORYPATTERN = Pattern.compile("(.*)/done/(.*)/([0-9]{4})/([0-9]{2})/([0-9]{2})/(.*)/(.*)");
 }

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/FileLister.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/FileLister.java
@@ -118,7 +118,9 @@ public class FileLister {
 
     LOG.info(" in getListFilesToProcess maxFileSize=" + maxFileSize
         + " inputPath= " + inputPath.toUri());
-    FileStatus[] origList = listFiles(recurse, hdfs, inputPath, pathFilter);
+    //Instead of getting a base path and recursing, we insist on getting a path pattern
+    //and using globStatus to return all files instead, which is much faster than the recursive method call:
+    FileStatus[] origList = hdfs.globStatus(inputPath, pathFilter);
     if (origList == null) {
       LOG.info(" No files found, orig list returning 0");
       return new FileStatus[0];


### PR DESCRIPTION
Right now hraven accepts a simple hdfs path as input folder and will fetch all job history + conf files underneath it. This pull request adds support for specifying a pattern with wildcards (*) and using hdfs api's globStatus method to list files instead of hraven's recursive listFiles method. This way one can easily shard hraven's job to different years/months/days.
