### PR TITLE
Remove copying of cost file from local to HDFS

### DIFF
--- a/bin/etl/hraven-etl.sh
+++ b/bin/etl/hraven-etl.sh
@@ -35,7 +35,7 @@ schedulerpoolname="mypool" #name of scheduler pool (arbitrary)
 threads="20"
 defaultrawfilesizelimit="524288000"
 machinetype="mymachine" #name of machine (arbitrary)
-costfile=/var/lib/hraven/conf/costFile
+
 #conf directories
 hadoopconfdir=${HADOOP_CONF_DIR:-$HADOOP_HOME/conf}
 hbaseconfdir=${HBASE_CONF_DIR:-$HBASE_HOME/conf}
@@ -44,11 +44,6 @@ historyRawDir=/yarn/history/done/
 historyProcessingDir=/hraven/processing/
 #######################################################
 
-#If costfile is empty, fill it with default values
-if [[ -z `cat $costfile` ]]; then
-  echo "$machinetype.computecost=3.0" > $costfile
-  echo "$machinetype.machinememory=12000" >> $costfile
-fi
 
 source $(dirname $0)/hraven-etl-env.sh
 
@@ -71,4 +66,4 @@ $home/jobFilePreprocessor.sh $hadoopconfdir $historyRawDir $historyProcessingDir
 $home/jobFileLoader.sh $hadoopconfdir $mapredmaxsplitsize $schedulerpoolname $cluster $historyProcessingDir
 
 # Process
-$home/jobFileProcessor.sh $hbaseconfdir $schedulerpoolname $historyProcessingDir $cluster $threads $batchsize $machinetype $costfile
+$home/jobFileProcessor.sh $hbaseconfdir $schedulerpoolname $historyProcessingDir $cluster $threads $batchsize $machinetype

--- a/bin/etl/jobFileProcessor.sh
+++ b/bin/etl/jobFileProcessor.sh
@@ -21,9 +21,9 @@
 #   [schedulerpoolname] [historyprocessingdir] [cluster] [threads] [batchsize] [machinetype] [costfile]
 # a sample cost file can be found in the conf dir as sampleCostDetails.properties
 
-if [ $# -ne 8 ]
+if [ $# -ne 7 ]
 then
-  echo "Usage: `basename $0` [hbaseconfdir] [schedulerpoolname] [historyprocessingdir] [cluster] [threads] [batchsize] [machinetype] [costfile]"
+  echo "Usage: `basename $0` [hbaseconfdir] [schedulerpoolname] [historyprocessingdir] [cluster] [threads] [batchsize] [machinetype]"
   exit 1
 fi
 
@@ -40,5 +40,5 @@ fi
 create_pidfile $HRAVEN_PID_DIR
 trap 'cleanup_pidfile_and_exit $HRAVEN_PID_DIR' INT TERM EXIT
 
-hadoop --config $1 jar $hravenEtlJar com.twitter.hraven.etl.JobFileProcessor -libjars=$LIBJARS -Dmapred.fairscheduler.pool=$2 -d -p $3 -c $4 -t $5 -b $6 -m $7 -z $8
+hadoop --config $1 jar $hravenEtlJar com.twitter.hraven.etl.JobFileProcessor -libjars=$LIBJARS -Dmapred.fairscheduler.pool=$2 -d -p $3 -c $4 -t $5 -b $6 -m $7
 

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFileProcessor.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFileProcessor.java
@@ -152,10 +152,8 @@ public class JobFileProcessor extends Configured implements Tool {
     // Debugging
     options.addOption("d", "debug", false, "switch on DEBUG log level");
 
-    // Cost Properties File to be copied to distributed cache
-    o = new Option("z", "costFile", true,
-      "The cost properties file on local disk");
-    o.setArgName("costfile");
+    o = new Option("zf", "costFile", true, "The cost properties file location on HDFS");
+    o.setArgName("costfile_loc");
     o.setRequired(true);
     options.addOption(o);
 
@@ -249,18 +247,15 @@ public class JobFileProcessor extends Configured implements Tool {
     }
 
     // Grab the costfile argument
-    String costFile = commandLine.getOptionValue("z");
-    LOG.info("cost properties file=" + costFile);
-    FileSystem fs = FileSystem.get(hbaseConf);
-    Path hdfsPath = new Path(Constants.COST_PROPERTIES_HDFS_DIR
-      + Constants.COST_PROPERTIES_FILENAME);
-    // upload the file to hdfs. Overwrite any existing copy.
-    fs.copyFromLocalFile(false, true, new Path(costFile), hdfsPath);
 
+    String costFilePath = commandLine.getOptionValue("zf");
+    LOG.info("cost properties file on hdfs=" + costFilePath);
+    if (costFilePath == null) costFilePath = Constants.COST_PROPERTIES_HDFS_DIR;
+    Path hdfsPath = new Path(costFilePath + Constants.COST_PROPERTIES_FILENAME);
     // add to distributed cache
     DistributedCache.addCacheFile(hdfsPath.toUri(), hbaseConf);
+    
     // Grab the machine type argument
-
     String machineType = commandLine.getOptionValue("m");
     // set it as part of conf so that the
     // hRaven job can access it in the mapper


### PR DESCRIPTION
This is needed for running hraven using oozie/falcon or any job scheduler. Oozie can spawn hraven from any node, so cannot copy cost file from local filesystem. Removed the "z" option. Instead ask for cost file path on hdfs ("zf")
