### PR TITLE
Set tmpjars for hadoop

### DIFF
--- a/hraven-core/src/main/java/com/twitter/hraven/Constants.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/Constants.java
@@ -426,4 +426,8 @@ public class Constants {
 
   /** name of the properties file used for cluster to cluster identifier mapping */
   public static final String HRAVEN_CLUSTER_PROPERTIES_FILENAME = "hRavenClusters.properties";
+
+  public static final String HRAVEN_HDFS_LIB_PATH_CONF = "hraven.conf.libpath";
+
+  public static final String HADOOP_TMP_JARS_CONF = "tmpjars";
 }

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/HadoopUtil.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/HadoopUtil.java
@@ -1,0 +1,27 @@
+package com.twitter.hraven.etl;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.twitter.hraven.Constants;
+
+public class HadoopUtil {
+  public static void setTmpJars(String libPathConf, Configuration conf) throws IOException {
+    StringBuilder tmpjars = new StringBuilder();
+    if (conf.get(libPathConf) != null) {
+      FileSystem fs = FileSystem.get(conf);
+      FileStatus[] files = fs.listStatus(new Path(conf.get(libPathConf)));
+      if (files != null) {
+        for (FileStatus file : files) {
+          if (!tmpjars.toString().isEmpty()) tmpjars = tmpjars.append(",");
+          tmpjars = tmpjars.append(file.getPath());
+        }
+        conf.set(Constants.HADOOP_TMP_JARS_CONF, tmpjars.toString());
+      }
+    }
+  }
+}

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFileProcessor.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFileProcessor.java
@@ -603,6 +603,9 @@ public class JobFileProcessor extends Configured implements Tool {
     // Note: must be BEFORE the job construction with the new mapreduce API.
     confClone.setBoolean("mapred.map.tasks.speculative.execution", false);
 
+    //Set tmpjars for hadoop to be able to find hraven-core and other required libs
+    HadoopUtil.setTmpJars(Constants.HRAVEN_HDFS_LIB_PATH_CONF, confClone);
+        
     // Set up job
     Job job = new Job(confClone, getJobName(totalJobCount));
 

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFileRawLoader.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFileRawLoader.java
@@ -282,6 +282,9 @@ public class JobFileRawLoader extends Configured implements Tool {
     // Note: must be BEFORE the job construction with the new mapreduce API.
     myHBaseConf.setBoolean("mapred.map.tasks.speculative.execution", false);
 
+    // Set tmpjars for hadoop to be able to find hraven-core and other required libs
+    HadoopUtil.setTmpJars(Constants.HRAVEN_HDFS_LIB_PATH_CONF, myHBaseConf);
+    
     // Set up job
     Job job = new Job(myHBaseConf, getJobName(totalJobCount));
     job.setJarByClass(JobFileRawLoader.class);


### PR DESCRIPTION
to be able to find hraven-core and other required libs.

this is needed when hraven jobs are spawned from oozie/falcon.
