### PR TITLE
bugfix: getLastSuccessfulProcessRecord not taking processingDirectory

### DIFF
--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFilePreprocessor.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFilePreprocessor.java
@@ -297,7 +297,7 @@ public class JobFilePreprocessor extends Configured implements Tool {
 
       if (!forceAllFiles) {
         lastProcessRecord = processRecordService
-            .getLastSuccessfulProcessRecord(cluster);
+            .getLastSuccessfulProcessRecord(cluster, output);
       }
 
       long minModificationTimeMillis = 0;

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
@@ -148,10 +148,10 @@ public class ProcessRecordService {
    *         state.
    * @throws IOException
    */
-  public ProcessRecord getLastSuccessfulProcessRecord(String cluster)
+  public ProcessRecord getLastSuccessfulProcessRecord(String cluster, String processFileSubstring)
       throws IOException {
     List<ProcessRecord> processRecords = getProcessRecords(cluster, NOT_EQUAL,
-        CREATED, 1, null);
+        CREATED, 1, processFileSubstring);
     if (processRecords.size() > 0) {
       return processRecords.get(0);
     }


### PR DESCRIPTION
Needed for example, for the ability to run hraven in an idempotent way for each day/shard's run and being able to rerun a shard's run and expect hraven to just resume instead of reprocessing everything.
