### PR TITLE
Ensuring job id is set while parsing history files (for aggregation)

### DIFF
--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParserHadoop2.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobHistoryFileParserHadoop2.java
@@ -589,6 +589,7 @@ public class JobHistoryFileParserHadoop2 extends JobHistoryFileParserBase {
     if (id != null && id.startsWith("job_") && id.length() > 4) {
       this.jobNumber = id.substring(4);
     }
+      this.jobDetails.setJobId(id);
   }
 
   /**

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobHistoryListener.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobHistoryListener.java
@@ -258,6 +258,7 @@ public class JobHistoryListener implements Listener {
     if (id != null && id.startsWith("job_") && id.length() > 4) {
       this.jobNumber = id.substring(4);
     }
+      this.jobDetails.setJobId(id);
   }
 
   /**


### PR DESCRIPTION

This was perhaps missing when we merged master and twitter only branches. Adding it back to ensure aggregation works fine