### PR TITLE
Add support to request for compressed payloads from the HRavenRestClient

### DIFF
--- a/hraven-core/pom.xml
+++ b/hraven-core/pom.xml
@@ -234,6 +234,17 @@
       <version>2.5</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <!-- used in the rest client -->
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.6.1</version>

--- a/hraven-core/src/main/java/com/twitter/hraven/rest/client/UrlDataLoader.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/rest/client/UrlDataLoader.java
@@ -68,7 +68,7 @@ class UrlDataLoader<T> {
         LOG.info("Not using compression!");
         httpClientBuilder.disableContentCompression();
       } else {
-        LOG.info("Using compression by default! Trying gzip, deflate");
+        LOG.debug("Using compression by default! Trying gzip, deflate");
       }
 
       CloseableHttpClient httpClient = httpClientBuilder.build();

--- a/hraven-core/src/main/java/com/twitter/hraven/rest/client/UrlDataLoader.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/rest/client/UrlDataLoader.java
@@ -16,23 +16,38 @@ class UrlDataLoader<T> {
 
     private static final Log LOG = LogFactory.getLog(UrlDataLoader.class);
 
+    private static final String ACCEPT_ENCODING = "Accept-Encoding";
+
     private String endpointURL;
     private TypeReference typeRef;
     private int connectTimeout;
     private int readTimeout;
+    private boolean useCompression;
 
     /**
-     * Constructor.
+     * Constructor, defaults to using compression (gzip / deflate).
      * @param endpointUrl
      * @param t TypeReference for json deserialization, should be TypeReference<List<T>>.
      * @throws java.io.IOException
      */
     public UrlDataLoader(String endpointUrl, TypeReference t, int connectTimeout, int readTimeout)
         throws IOException {
+      this(endpointUrl, t, connectTimeout, readTimeout, true);
+    }
+
+    /**
+     * Constructor.
+     * @param endpointUrl
+     * @param t TypeReference for json deserialization, should be TypeReference<List<T>>.
+     * @throws java.io.IOException
+    */
+    public UrlDataLoader(String endpointUrl, TypeReference t, int connectTimeout, int readTimeout,
+                         boolean useCompression) throws IOException {
       this.endpointURL = endpointUrl;
       this.typeRef = t;
       this.connectTimeout = connectTimeout;
       this.readTimeout = readTimeout;
+      this.useCompression = useCompression;
     }
 
     @SuppressWarnings("unchecked")
@@ -43,6 +58,9 @@ class UrlDataLoader<T> {
         URLConnection connection = url.openConnection();
         connection.setConnectTimeout(connectTimeout);
         connection.setReadTimeout(readTimeout);
+        if (useCompression) {
+          connection.setRequestProperty(ACCEPT_ENCODING, "gzip, deflate");
+        }
         input = connection.getInputStream();
         return (List<T>) JSONUtil.readJson(input, typeRef);
       } finally {


### PR DESCRIPTION
Noticed that even with counter filtering (https://github.com/twitter/hraven/pull/160), some of our payloads are multiple MB in size. The hraven server seems to support gzip as an accept-encoding option and when we use that it compresses the payload substantially in some cases (e.g. one call when down to 32K from 1.45MB). Can observe this behavior via curl:
```
curl -v --output /dev/null  -H "Accept-Encoding: gzip" -X GET  "http://hraven.devel.host/api/v1/tasks/procrev@atla/job_1486504431708_30155?include=taskType&include=taskId"

> GET /api/v1/tasks/procrev@atla/job_1486504431708_30155?include=taskType&include=taskId HTTP/1.1
> Host: hraven.devel.host
> User-Agent: curl/7.51.0
> Accept: */*
> Accept-Encoding: gzip
> 
  0     0    0     0    0     0      0      0 --:--:--  0:00:07 --:--:--     0< HTTP/1.1 200 OK
< Content-Type: application/json
< Server: Jetty(6.1.26)
< Content-Encoding: gzip
< Content-Length: 32677
```

I updated the UrlDataLoader to use the apache HTTP libraries. The libraries are setup to use Accept-encoding = "gzip,deflate" by default. In case users of HRavenRestClient explicitly want to not use compression, they can opt out. 
Tested the code out with compression on and off. 